### PR TITLE
Preemptively add RTL language layout

### DIFF
--- a/app/css/main.css
+++ b/app/css/main.css
@@ -2125,3 +2125,24 @@ body {
   width: 350px;
   margin-top: 15px;
   overflow: hidden; }
+
+[dir="rtl"] nav > img, [dir="rtl"] nav > h1 {
+  float: right !important; }
+
+[dir="rtl"] nav > ul {
+  float: left !important; }
+
+[dir="rtl"] nav li.nav {
+  margin-left: 55px;
+  margin-right: 0; }
+  [dir="rtl"] nav li.nav:last-child {
+    margin-left: 30px;
+    margin-right: 0; }
+
+[dir="rtl"] nav.margin-circles, [dir="rtl"] .lang-toggle {
+  left: auto;
+  right: 30px; }
+
+[dir="rtl"] #address-form .borough-select:after {
+  left: 20px;
+  right: auto; }

--- a/app/js/app/app.lang-toggle.js
+++ b/app/js/app/app.lang-toggle.js
@@ -37,6 +37,11 @@ app.language = (function(w,d,$) {
       } else  {
         html = template(data.languages.en);
       }
+      /*
+      if (['ar', 'fa', 'he'].indexOf(lang) > -1) {
+        d.querySelector('#wrapper').dir = 'rtl';
+      }
+      */
       d.querySelector('#wrapper').innerHTML = html;
       initLangButtons();
     })

--- a/app/js/app/templates.js
+++ b/app/js/app/templates.js
@@ -130,7 +130,7 @@ this["app"]["templates"]["main"] = Handlebars.template({"compiler":[7,">= 4.0.0"
     + alias2(alias1(((stack1 = (depth0 != null ? depth0.slide02 : depth0)) != null ? stack1.h1 : stack1), depth0))
     + "</h1>\n        <p class=\"step\">"
     + alias2(alias1(((stack1 = (depth0 != null ? depth0.slide02 : depth0)) != null ? stack1.privacy : stack1), depth0))
-    + "</p>\n\n        <form id=\"address-form\">\n          <div class=\"user-data street-address\">\n              <input class=\"address-input\" name=\"address-input\" type=\"text\" placeholder=\""
+    + "</p>\n\n        <form id=\"address-form\">\n          <div class=\"user-data street-address\">\n              <input class=\"address-input\" name=\"address-input\" type=\"text\" dir=\"auto\" placeholder=\""
     + ((stack1 = alias1(((stack1 = ((stack1 = (depth0 != null ? depth0.slide02 : depth0)) != null ? stack1.form : stack1)) != null ? stack1.address : stack1), depth0)) != null ? stack1 : "")
     + "\" tabindex=\"1\">\n          </div>\n          <div class=\"user-data borough-select\">\n              <span id=\"select-boro\"> "
     + ((stack1 = alias1(((stack1 = ((stack1 = (depth0 != null ? depth0.slide02 : depth0)) != null ? stack1.form : stack1)) != null ? stack1.boro_select : stack1), depth0)) != null ? stack1 : "")

--- a/app/scss/_rtl.scss
+++ b/app/scss/_rtl.scss
@@ -1,0 +1,29 @@
+[dir="rtl"] {
+  nav > img, nav > h1 {
+    float: right !important;
+  }
+
+  nav > ul {
+    float: left !important;
+  }
+
+  nav li.nav {
+    margin-left: 55px;
+    margin-right: 0;
+
+    &:last-child {
+      margin-left: 30px;
+      margin-right: 0;
+    }
+  }
+
+  nav.margin-circles, .lang-toggle {
+    left: auto;
+    right: 30px;
+  }
+
+  #address-form .borough-select:after {
+    left: 20px;
+    right: auto;
+  }
+}

--- a/app/scss/main.scss
+++ b/app/scss/main.scss
@@ -19,4 +19,5 @@
 "other_pages_nav",
 "other_pages_main_content",
 "mobile_message",
-"tr_orgs_modal";
+"tr_orgs_modal",
+"rtl";


### PR DESCRIPTION
Hi !
I saw a mention of AmIRentStabilized the other day and although only Spanish and Chinese translations are currently supported, I thought I could do some quick CSS work so if this were translated into Arabic, Farsi, Hebrew, or forked for some other purpose, the CSS layout would support it.