### PR TITLE
bug fix for searching incorrect address (#77)

### DIFF
--- a/app/src/action_creators/searchRentStabilizedActions.js
+++ b/app/src/action_creators/searchRentStabilizedActions.js
@@ -44,15 +44,15 @@ export function getBBL(feature) {
  * 4. going to the "you might/might not be rent stabilized" slide
  * 5. OR going back to the address search slide if an error occurs
  */
-export const searchRentStabilized = (address) => async (dispatch) => {
+export const searchRentStabilized = (addressInfo) => async (dispatch) => {
   try {
     let searchResult;
 
-    if (typeof address === "string") {
-      searchResult = await dispatch(addressSearchFetch(address));
-    } else if (typeof address === "object" && "features" in address) {
-      dispatch(addressSearchSuccess(address));
-      searchResult = { ...address };
+    if (typeof addressInfo === "string") {
+      searchResult = await dispatch(addressSearchFetch(addressInfo));
+    } else if (typeof addressInfo === "object" && "features" in addressInfo) {
+      dispatch(addressSearchSuccess(addressInfo));
+      searchResult = { ...addressInfo };
     } else {
       throw new Error(
         "param `address` must be an address (string) or object (FeatureCollection)"

--- a/app/src/action_creators/searchRentStabilizedActions.js
+++ b/app/src/action_creators/searchRentStabilizedActions.js
@@ -36,7 +36,7 @@ export function getBBL(feature) {
 
 /**
  * searchRentStabilized
- * @param {string | object } address The address to be searched
+ * @param {string | object } addressInfo The address to be searched
  * This is a compound action creator that handles:
  * 1. geocoding an address inputted by the user
  * 2. looking up the result in the rent stabilized data

--- a/app/src/action_creators/searchRentStabilizedActions.js
+++ b/app/src/action_creators/searchRentStabilizedActions.js
@@ -40,12 +40,20 @@ export function getBBL(feature) {
  * 4. going to the "you might/might not be rent stabilized" slide
  * 5. OR going back to the address search slide if an error occurs
  */
-export const searchRentStabilized = (addressText) => async (dispatch) => {
+export const searchRentStabilized = (addressOrBbl) => async (dispatch) => {
   try {
-    const searchResult = await dispatch(addressSearchFetch(addressText));
-    validateSearchResult(searchResult);
+    let bbl;
 
-    const bbl = getBBL(searchResult.features[0]);
+    if (typeof addressOrBbl === "string") {
+      const searchResult = await dispatch(addressSearchFetch(addressOrBbl));
+      validateSearchResult(searchResult);
+      bbl = getBBL(searchResult.features[0]);
+    } else if (typeof addressOrBbl === "number") {
+      bbl = addressOrBbl;
+    } else {
+      throw new Error("arg must be an address (string) or bbl (number)");
+    }
+
     const rsResult = await dispatch(fetchRentStabilized(bbl));
     validateRS(rsResult);
 

--- a/app/src/action_creators/searchRentStabilizedActions.spec.js
+++ b/app/src/action_creators/searchRentStabilizedActions.spec.js
@@ -81,7 +81,7 @@ describe("searchRentStabilized", () => {
     fetch.resetMocks();
   });
 
-  test("It dispatches expected actions when encountering no errors", () => {
+  test("It dispatches expected actions when param is a string", () => {
     fetch
       .mockResponseOnce(
         JSON.stringify({ features: [{ properties: { pad_bbl: "000222" } }] }),
@@ -107,6 +107,36 @@ describe("searchRentStabilized", () => {
     ];
 
     return store.dispatch(searchRentStabilized("Some NYC address")).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  test("It dispatches expected actions when param is an object", () => {
+    fetch.mockResponseOnce(JSON.stringify({ rows: [] }), {
+      status: 200,
+      statusText: "OK",
+    });
+
+    const param = {
+      type: "FeatureCollection",
+      features: [
+        {
+          properties: { pad_bbl: "000222" },
+        },
+      ],
+    };
+
+    const expectedActions = [
+      {
+        type: types.AddressSearchSuccess,
+        payload: { ...param },
+      },
+      { type: types.RentStabilizedRequest },
+      { type: types.RentStabilizedSuccess, payload: { rows: [] } },
+      { type: types.GoToSlideIdx, payload: 3 },
+    ];
+
+    return store.dispatch(searchRentStabilized(param)).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });

--- a/app/src/components/addressSearchForm.js
+++ b/app/src/components/addressSearchForm.js
@@ -83,31 +83,31 @@ export class AddressSearchForm extends Component {
     event.preventDefault();
     this.handleInputChange.cancel();
     this.clearCachedSearchResult();
-    const value = this.inputAddress.value;
+    const addressToSearch = this.inputAddress.value;
 
-    if (!value.length) {
+    if (!addressToSearch.length) {
       this.validationErrors.showNoInput();
       return;
     }
 
-    if (this.autosuggestionsList) {
-      const match = this.autosuggestionsList.filter(
-        (d) => d.properties.label === value
+    const autosuggestMatch =
+      this.autosuggestionsList &&
+      this.autosuggestionsList.find(
+        (d) => d.properties.label === addressToSearch
       );
-      if (match.length) {
-        this.store.dispatch(
-          searchRentStabilized({
-            type: "FeatureCollection",
-            features: match,
-          })
-        );
-      } else {
-        this.store.dispatch(searchRentStabilized(value));
-      }
+
+    if (autosuggestMatch) {
+      this.store.dispatch(
+        searchRentStabilized({
+          type: "FeatureCollection",
+          features: [autosuggestMatch],
+        })
+      );
     } else {
-      this.store.dispatch(searchRentStabilized(value));
+      this.store.dispatch(searchRentStabilized(addressToSearch));
     }
-    logAddressSearch(value);
+
+    logAddressSearch(addressToSearch);
     this.inputAddress.value = "";
   }
 

--- a/app/src/components/addressSearchForm.js
+++ b/app/src/components/addressSearchForm.js
@@ -84,13 +84,26 @@ export class AddressSearchForm extends Component {
     this.handleInputChange.cancel();
     this.clearCachedSearchResult();
     const value = this.inputAddress.value;
-    if (value.length) {
-      this.store.dispatch(searchRentStabilized(value));
-      logAddressSearch(value);
-      this.inputAddress.value = "";
-    } else {
+
+    if (!value.length) {
       this.validationErrors.showNoInput();
+      return;
     }
+
+    if (this.autosuggestionsList) {
+      const match = this.autosuggestionsList.filter(
+        (d) => d.properties.label === value
+      );
+      if (match.length) {
+        this.store.dispatch(searchRentStabilized(+match[0].properties.pad_bbl));
+      } else {
+        this.store.dispatch(searchRentStabilized(value));
+      }
+    } else {
+      this.store.dispatch(searchRentStabilized(value));
+    }
+    logAddressSearch(value);
+    this.inputAddress.value = "";
   }
 
   handleInputChange(event) {
@@ -135,6 +148,7 @@ export class AddressSearchForm extends Component {
     this.autosuggestionsList.forEach(({ properties }) => {
       const option = document.createElement("option");
       option.value = properties.label || "";
+      option.dataset.bbl = properties.pad_bbl;
       this.datalist.appendChild(option);
     });
   }

--- a/app/src/components/addressSearchForm.js
+++ b/app/src/components/addressSearchForm.js
@@ -95,7 +95,12 @@ export class AddressSearchForm extends Component {
         (d) => d.properties.label === value
       );
       if (match.length) {
-        this.store.dispatch(searchRentStabilized(+match[0].properties.pad_bbl));
+        this.store.dispatch(
+          searchRentStabilized({
+            type: "FeatureCollection",
+            features: match,
+          })
+        );
       } else {
         this.store.dispatch(searchRentStabilized(value));
       }

--- a/app/src/components/addressSearchForm.js
+++ b/app/src/components/addressSearchForm.js
@@ -154,7 +154,6 @@ export class AddressSearchForm extends Component {
     this.autosuggestionsList.forEach(({ properties }) => {
       const option = document.createElement("option");
       option.value = properties.label || "";
-      option.dataset.bbl = properties.pad_bbl;
       this.datalist.appendChild(option);
     });
   }

--- a/app/src/components/addressSearchForm.js
+++ b/app/src/components/addressSearchForm.js
@@ -83,17 +83,21 @@ export class AddressSearchForm extends Component {
     event.preventDefault();
     this.handleInputChange.cancel();
     this.clearCachedSearchResult();
-    const addressToSearch = this.inputAddress.value;
 
-    if (!addressToSearch.length) {
+    if (this.inputAddress.value.length) {
+      this.searchRentStabilized(this.inputAddress.value);
+      logAddressSearch(this.inputAddress.value);
+      this.inputAddress.value = "";
+    } else {
       this.validationErrors.showNoInput();
-      return;
     }
+  }
 
+  searchRentStabilized(anAddressString) {
     const autosuggestMatch =
       this.autosuggestionsList &&
       this.autosuggestionsList.find(
-        (d) => d.properties.label === addressToSearch
+        (d) => d.properties.label === anAddressString
       );
 
     if (autosuggestMatch) {
@@ -104,11 +108,8 @@ export class AddressSearchForm extends Component {
         })
       );
     } else {
-      this.store.dispatch(searchRentStabilized(addressToSearch));
+      this.store.dispatch(searchRentStabilized(anAddressString));
     }
-
-    logAddressSearch(addressToSearch);
-    this.inputAddress.value = "";
   }
 
   handleInputChange(event) {

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2478,9 +2478,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001111:
-  version "1.0.30001117"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001117.tgz#69a9fae5d480eaa9589f7641a83842ad396d17c4"
-  integrity sha512-4tY0Fatzdx59kYjQs+bNxUwZB03ZEBgVmJ1UkFPz/Q8OLiUUbjct2EdpnXj0fvFTPej2EkbPIG0w8BWsjAyk1Q==
+  version "1.0.30001180"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001180.tgz"
+  integrity sha512-n8JVqXuZMVSPKiPiypjFtDTXc4jWIdjxull0f92WLo7e1MSi3uJ3NvveakSh/aCl1QKFAvIz3vIj0v+0K+FrXw==
 
 capture-exit@^2.0.0:
   version "2.0.0"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2478,9 +2478,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001111:
-  version "1.0.30001180"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001180.tgz"
-  integrity sha512-n8JVqXuZMVSPKiPiypjFtDTXc4jWIdjxull0f92WLo7e1MSi3uJ3NvveakSh/aCl1QKFAvIz3vIj0v+0K+FrXw==
+  version "1.0.30001117"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001117.tgz#69a9fae5d480eaa9589f7641a83842ad396d17c4"
+  integrity sha512-4tY0Fatzdx59kYjQs+bNxUwZB03ZEBgVmJ1UkFPz/Q8OLiUUbjct2EdpnXj0fvFTPej2EkbPIG0w8BWsjAyk1Q==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes #77 

TODO:

- [x] update unit tests

Instead of always making a request to the GeoSearch `search` API endpoint when the user submits the address search form, check if a user selected an address from the auto-suggestions list. If so then pass that list item's data to the rent-stabilized search as well as store its location data for displaying in the search result map.