### PR TITLE
bug fix: broken geocoding service 

### DIFF
--- a/app/src/action_creators/addressGeocodeActions.js
+++ b/app/src/action_creators/addressGeocodeActions.js
@@ -1,5 +1,6 @@
 import "cross-fetch/polyfill";
 import * as types from "../constants/actionTypes";
+import { geosearchApiVersion } from "../constants/config";
 
 export const resetAddressState = () => ({
   type: types.ResetAddressState,
@@ -25,7 +26,7 @@ export const addressAutosuggestFailure = (error) => ({
 export const addressAutosuggestFetch = (text) => (dispatch) => {
   dispatch(addressAutosuggestRequest());
   return fetch(
-    `https://geosearch.planninglabs.nyc/v1/autocomplete?text=${text}&size=5`
+    `https://geosearch.planninglabs.nyc/${geosearchApiVersion}/autocomplete?text=${text}&size=5`
   )
     .then((response) => {
       if (response.ok) {
@@ -62,7 +63,7 @@ export const addressSearchFailure = (error) => ({
 export const addressSearchFetch = (text) => (dispatch) => {
   dispatch(addressSearchRequest());
   return fetch(
-    `https://geosearch.planninglabs.nyc/v1/search?text=${text}&size=1`
+    `https://geosearch.planninglabs.nyc/${geosearchApiVersion}/search?text=${text}&size=1`
   )
     .then((response) => {
       if (response.ok) {

--- a/app/src/action_creators/searchRentStabilizedActions.js
+++ b/app/src/action_creators/searchRentStabilizedActions.js
@@ -30,12 +30,7 @@ export function validateRS(result) {
 }
 
 export function getBBL(feature) {
-  if (
-    !feature ||
-    !feature.properties ||
-    !feature.properties.addendum ||
-    !feature.properties.addendum.pad
-  ) {
+  if (!feature?.properties?.addendum?.pad?.bbl) {
     throw new Error(ERROR_MISSING_BBL);
   }
   return feature.properties.addendum.pad.bbl;

--- a/app/src/action_creators/searchRentStabilizedActions.js
+++ b/app/src/action_creators/searchRentStabilizedActions.js
@@ -30,10 +30,15 @@ export function validateRS(result) {
 }
 
 export function getBBL(feature) {
-  if (!feature || !feature.properties || !feature.properties.pad_bbl) {
+  if (
+    !feature ||
+    !feature.properties ||
+    !feature.properties.addendum ||
+    !feature.properties.addendum.pad
+  ) {
     throw new Error(ERROR_MISSING_BBL);
   }
-  return feature.properties.pad_bbl;
+  return feature.properties.addendum.pad.bbl;
 }
 
 /**

--- a/app/src/action_creators/searchRentStabilizedActions.spec.js
+++ b/app/src/action_creators/searchRentStabilizedActions.spec.js
@@ -63,7 +63,9 @@ describe("getBBL", () => {
   });
 
   test("valid input", () => {
-    expect(getBBL({ properties: { pad_bbl: "01234" } })).toBe("01234");
+    expect(
+      getBBL({ properties: { addendum: { pad: { bbl: "01234" } } } })
+    ).toBe("01234");
   });
 });
 
@@ -84,7 +86,9 @@ describe("searchRentStabilized", () => {
   test("It dispatches expected actions when param is a string", () => {
     fetch
       .mockResponseOnce(
-        JSON.stringify({ features: [{ properties: { pad_bbl: "000222" } }] }),
+        JSON.stringify({
+          features: [{ properties: { addendum: { pad: { bbl: "01234" } } } }],
+        }),
         {
           status: 200,
           statusText: "OK",
@@ -99,7 +103,9 @@ describe("searchRentStabilized", () => {
       { type: types.AddressSearchRequest },
       {
         type: types.AddressSearchSuccess,
-        payload: { features: [{ properties: { pad_bbl: "000222" } }] },
+        payload: {
+          features: [{ properties: { addendum: { pad: { bbl: "01234" } } } }],
+        },
       },
       { type: types.RentStabilizedRequest },
       { type: types.RentStabilizedSuccess, payload: { rows: [] } },
@@ -119,11 +125,7 @@ describe("searchRentStabilized", () => {
 
     const param = {
       type: "FeatureCollection",
-      features: [
-        {
-          properties: { pad_bbl: "000222" },
-        },
-      ],
+      features: [{ properties: { addendum: { pad: { bbl: "01234" } } } }],
     };
 
     const expectedActions = [
@@ -206,7 +208,13 @@ describe("searchRentStabilized", () => {
   test("It handles RS server error", () => {
     fetch
       .mockResponseOnce(
-        JSON.stringify({ features: [{ properties: { pad_bbl: "01010101" } }] }),
+        JSON.stringify({
+          features: [
+            {
+              properties: { addendum: { pad: { bbl: "01234" } } },
+            },
+          ],
+        }),
         {
           status: 200,
           statusText: "OK",
@@ -218,7 +226,13 @@ describe("searchRentStabilized", () => {
       { type: types.AddressSearchRequest },
       {
         type: types.AddressSearchSuccess,
-        payload: { features: [{ properties: { pad_bbl: "01010101" } }] },
+        payload: {
+          features: [
+            {
+              properties: { addendum: { pad: { bbl: "01234" } } },
+            },
+          ],
+        },
       },
       {
         type: types.RentStabilizedRequest,

--- a/app/src/constants/config.js
+++ b/app/src/constants/config.js
@@ -1,3 +1,4 @@
 // CARTO account config related
 export const cartoAccount = "chenrick";
 export const rentStabilizedTable = "mappluto_likely_rs_2020_v8";
+export const geosearchApiVersion = 2;

--- a/app/src/constants/config.js
+++ b/app/src/constants/config.js
@@ -1,4 +1,4 @@
 // CARTO account config related
 export const cartoAccount = "chenrick";
 export const rentStabilizedTable = "mappluto_likely_rs_2020_v8";
-export const geosearchApiVersion = 2;
+export const geosearchApiVersion = "v2";

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2479,9 +2479,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219:
-  version "1.0.30001230"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz#8135c57459854b2240b57a4a6786044bdc5a9f71"
-  integrity sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==
+  version "1.0.30001450"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001450.tgz"
+  integrity sha512-qMBmvmQmFXaSxexkjjfMvD5rnDL0+m+dUMZKoDYsGG8iZN29RuYh9eRoMvKsT6uMAWlyUUGDEQGJJYjzCIO9ew==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Addresses #119

Updates the geocoding service to use NYC Planning Lab's Geosearch API **v2 endpoint** and new response schema. [Migration guide here](https://github.com/NYCPlanning/labs-geosearch-docker/blob/1febcfee9bd225c542edfe5fb1f0051c000cc955/MIGRATING.md).
