### PR TITLE
bug fix: slides smooth scroll animation

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "main": "src/index.js",
   "scripts": {
-    "start": "webpack-dev-server --mode=development --env.NODE_ENV=development",
+    "start": "webpack-dev-server --mode=development --env.NODE_ENV=development --env.USE_REDUX_LOGGER=true",
     "start:preloaded-state": "npm start -- --env.USE_PRELOADED_STATE=true",
     "start:prod": "serve dist",
     "webpack:debug": "webpack --debug=true --display-error-details=true --verbose=true --mode=development --env.NODE_ENV=development --env.USE_REDUX_LOGGER=true",
@@ -122,7 +122,7 @@
     "cross-fetch": "^3.1.5",
     "d3-geo": "^2.0.1",
     "d3-tile": "^1.0.0",
-    "gsap": "^3.6.0",
+    "gsap": "^3.12.2",
     "handlebars": "4.7.7",
     "innersvg-polyfill": "^0.0.5",
     "lodash.throttle": "^4.1.1",

--- a/app/package.json
+++ b/app/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "main": "src/index.js",
   "scripts": {
-    "start": "webpack-dev-server --mode=development --env.NODE_ENV=development --env.USE_REDUX_LOGGER=true",
+    "start": "webpack-dev-server --mode=development --env.NODE_ENV=development",
     "start:preloaded-state": "npm start -- --env.USE_PRELOADED_STATE=true",
     "start:prod": "serve dist",
     "webpack:debug": "webpack --debug=true --display-error-details=true --verbose=true --mode=development --env.NODE_ENV=development --env.USE_REDUX_LOGGER=true",

--- a/app/src/components/slidesContainer.js
+++ b/app/src/components/slidesContainer.js
@@ -29,7 +29,6 @@ export class SlidesContainer extends Component {
       (state) => state.slides,
       this.handleSlidesUpdate
     );
-    console.log(this.activeSlideIdx);
     this.scrollToActiveSlide();
   }
 
@@ -43,7 +42,6 @@ export class SlidesContainer extends Component {
 
   scrollToActiveSlide() {
     const id = `#slide-${this.activeSlideIdx + 1}`;
-    console.log(id);
     const duration = this.prefersReducedMotion ? 0 : SCROLL_DURATION_SECONDS;
     gsap.to(this.element, {
       duration,

--- a/app/src/components/slidesContainer.js
+++ b/app/src/components/slidesContainer.js
@@ -17,11 +17,12 @@ export class SlidesContainer extends Component {
 
     this.slides = [...this.element.querySelectorAll(".slide")];
     this.prefersReducedMotion = false;
-    this.activeSlide = this.store.getState().slides.curIndex;
+    this.activeSlide = this.slides[this.store.getState().slides.curIndex];
 
     this.handleSlidesUpdate = this.handleSlidesUpdate.bind(this);
     this.scrollToActiveSlide = this.scrollToActiveSlide.bind(this);
     this.handleMotionQuery = this.handleMotionQuery.bind(this);
+    this.handleScrollComplete = this.handleScrollComplete.bind(this);
 
     this.handleMotionQuery();
     this.unsubscribe = observeStore(
@@ -33,8 +34,10 @@ export class SlidesContainer extends Component {
   }
 
   handleSlidesUpdate() {
+    console.log("handleSlidesUpdate...");
     const { slides } = this.store.getState();
     if (slides.curIndex !== this.activeSlideIdx) {
+      this.previousSlideIndex = this.activeSlideIdx;
       this.activeSlide = slides.curIndex;
       this.scrollToActiveSlide();
     }
@@ -47,7 +50,12 @@ export class SlidesContainer extends Component {
       duration,
       scrollTo: id,
       ease: "sine.inOut",
+      onComplete: this.handleScrollComplete,
     });
+  }
+
+  handleScrollComplete() {
+    this.activeSlide.focus();
   }
 
   handleMotionQuery() {
@@ -63,7 +71,6 @@ export class SlidesContainer extends Component {
         slide.classList.add("active");
         slide.removeAttribute("inert");
         slide.setAttribute("aria-hidden", false);
-        slide.focus();
       } else {
         slide.classList.remove("active");
         slide.setAttribute("inert", true);

--- a/app/src/components/slidesContainer.js
+++ b/app/src/components/slidesContainer.js
@@ -3,6 +3,7 @@ import { ScrollToPlugin } from "gsap/ScrollToPlugin";
 import { Component } from "./_componentBase";
 import { observeStore } from "../store";
 
+// NOTE: this is required for GSAP plugins to work with module bundlers
 gsap.registerPlugin(ScrollToPlugin);
 
 export const SCROLL_DURATION_SECONDS = 0.65;
@@ -38,7 +39,7 @@ export class SlidesContainer extends Component {
     const { slides } = this.store.getState();
     if (slides.curIndex !== this.activeSlideIndex) {
       this.previousSlideIndex = this.activeSlideIndex;
-      this.activeSlide = slides.curIndex;
+      this.activeSlideIndex = slides.curIndex;
       this.scrollToActiveSlide();
     }
   }
@@ -77,9 +78,10 @@ export class SlidesContainer extends Component {
     }
   }
 
-  set activeSlide(index) {
+  /** updates a slide in the document to be the "active" one and all other slides to be "inactive" */
+  set activeSlide(target) {
     this.slides.forEach((slide) => {
-      if (slide === this.slides[index]) {
+      if (slide === target) {
         slide.classList.add("active");
         slide.removeAttribute("inert");
         slide.setAttribute("aria-hidden", false);
@@ -91,14 +93,17 @@ export class SlidesContainer extends Component {
     });
   }
 
+  /** returns the slide that currently has a class of "active" */
   get activeSlide() {
     return this.slides[this.activeSlideIndex];
   }
 
+  /** alias for setting activeSlide via an index */
   set activeSlideIndex(index) {
-    this.activeSlide = index;
+    this.activeSlide = this.slides[index];
   }
 
+  /** returns the index of the slide with a class of "active" */
   get activeSlideIndex() {
     return this.slides.findIndex((slide) => slide.classList.contains("active"));
   }

--- a/app/src/components/slidesContainer.js
+++ b/app/src/components/slidesContainer.js
@@ -5,7 +5,7 @@ import { observeStore } from "../store";
 
 gsap.registerPlugin(ScrollToPlugin);
 
-const SCROLL_DURATION_SECONDS = 0.65;
+export const SCROLL_DURATION_SECONDS = 0.65;
 
 export class SlidesContainer extends Component {
   constructor(props) {

--- a/app/src/components/slidesContainer.js
+++ b/app/src/components/slidesContainer.js
@@ -40,9 +40,12 @@ export class SlidesContainer extends Component {
   }
 
   scrollToActiveSlide() {
+    const id = `#slide-${this.activeSlideIdx + 1}`;
+    console.log(id);
+    const duration = this.prefersReducedMotion ? 0 : SCROLL_DURATION_SECONDS;
     gsap.to(this.element, {
-      duration: this.prefersReducedMotion ? 0 : SCROLL_DURATION_SECONDS,
-      scrollTo: ".slide.active",
+      duration,
+      scrollTo: id,
       ease: "sine.inOut",
     });
   }

--- a/app/src/components/slidesContainer.js
+++ b/app/src/components/slidesContainer.js
@@ -29,6 +29,8 @@ export class SlidesContainer extends Component {
       (state) => state.slides,
       this.handleSlidesUpdate
     );
+    console.log(this.activeSlideIdx);
+    this.scrollToActiveSlide();
   }
 
   handleSlidesUpdate() {

--- a/app/src/components/slidesContainer.js
+++ b/app/src/components/slidesContainer.js
@@ -59,9 +59,9 @@ export class SlidesContainer extends Component {
     }
   }
 
-  set activeSlide(value) {
+  set activeSlide(index) {
     this.slides.forEach((slide) => {
-      if (slide === this.slides[value]) {
+      if (slide === this.slides[index]) {
         slide.classList.add("active");
         slide.removeAttribute("inert");
         slide.setAttribute("aria-hidden", false);
@@ -78,8 +78,8 @@ export class SlidesContainer extends Component {
     return this.slides[this.activeSlideIdx];
   }
 
-  set activeSlideIdx(value) {
-    this.activeSlide = value;
+  set activeSlideIdx(index) {
+    this.activeSlide = index;
   }
 
   get activeSlideIdx() {

--- a/app/src/components/slidesContainer.js
+++ b/app/src/components/slidesContainer.js
@@ -17,7 +17,7 @@ export class SlidesContainer extends Component {
 
     this.slides = [...this.element.querySelectorAll(".slide")];
     this.prefersReducedMotion = false;
-    this.activeSlide = this.slides[this.store.getState().slides.curIndex];
+    this.activeSlideIdx = this.store.getState().slides.curIndex;
 
     this.handleSlidesUpdate = this.handleSlidesUpdate.bind(this);
     this.scrollToActiveSlide = this.scrollToActiveSlide.bind(this);
@@ -34,7 +34,6 @@ export class SlidesContainer extends Component {
   }
 
   handleSlidesUpdate() {
-    console.log("handleSlidesUpdate...");
     const { slides } = this.store.getState();
     if (slides.curIndex !== this.activeSlideIdx) {
       this.previousSlideIndex = this.activeSlideIdx;

--- a/app/src/components/slidesContainer.spec.js
+++ b/app/src/components/slidesContainer.spec.js
@@ -99,7 +99,7 @@ describe("SlidesContainer", () => {
       },
     }));
     slidesContainer.handleSlidesUpdate();
-    const activeSlideIndex = slidesContainer.activeSlideIdx;
+    const activeSlideIndex = slidesContainer.activeSlideIndex;
     const activeSlide = slidesContainer.activeSlide;
     const nonActiveSlides = slidesContainer.slides.filter(
       (slide) => !slide.classList.contains("active")
@@ -114,7 +114,7 @@ describe("SlidesContainer", () => {
     });
   });
 
-  test("scrollToActiveSlide calls gsap.to with expected params", () => {
+  test("scrollToActiveSlide calls gsap.to and gsap.fromTo with expected params", () => {
     gsap.to.mockClear();
     slidesContainer.scrollToActiveSlide();
     expect(gsap.to).toHaveBeenCalledTimes(1);
@@ -124,6 +124,21 @@ describe("SlidesContainer", () => {
       ease: "sine.inOut",
       onComplete: slidesContainer.handleScrollComplete,
     });
+
+    slidesContainer.activeSlideIndex = 2;
+    slidesContainer.previousSlideIndex = 1;
+    slidesContainer.scrollToActiveSlide();
+    expect(gsap.fromTo).toHaveBeenCalledTimes(1);
+    expect(gsap.fromTo).toHaveBeenCalledWith(
+      element,
+      { scrollTo: "#slide-2" },
+      {
+        duration: SCROLL_DURATION_SECONDS,
+        scrollTo: "#slide-3",
+        ease: "sine.inOut",
+        onComplete: slidesContainer.handleScrollComplete,
+      }
+    );
   });
 
   test("when scroll completes, active slide is focused", () => {

--- a/app/src/components/slidesContainer.spec.js
+++ b/app/src/components/slidesContainer.spec.js
@@ -126,12 +126,13 @@ describe("SlidesContainer", () => {
     });
   });
 
-  test("a11y: when scroll completes, active slide is focused", () => {
+  test("when scroll completes, active slide is focused", () => {
     slidesContainer.handleScrollComplete();
     expect(document.activeElement).toBe(slidesContainer.activeSlide);
   });
 
   test("checks prefers-reduced-motion media query", () => {
+    expect(slidesContainer.prefersReducedMotion).toBe(false);
     mockMatchMedia.mockImplementation(() => ({ matches: true }));
     slidesContainer = new SlidesContainer({
       element,

--- a/app/src/components/slidesContainer.spec.js
+++ b/app/src/components/slidesContainer.spec.js
@@ -99,8 +99,19 @@ describe("SlidesContainer", () => {
       },
     }));
     slidesContainer.handleSlidesUpdate();
+    const activeSlideIndex = slidesContainer.activeSlideIdx;
+    const activeSlide = slidesContainer.activeSlide;
+    const nonActiveSlides = slidesContainer.slides.filter(
+      (slide) => !slide.classList.contains("active")
+    );
     expect(spyScrollToActiveSlide).toHaveBeenCalledTimes(1);
-    expect(slidesContainer.activeSlideIdx).toBe(5);
+    expect(activeSlideIndex).toBe(5);
+    expect(activeSlide.getAttribute("inert")).toBeNull();
+    expect(activeSlide.getAttribute("aria-hidden")).toBe("false");
+    nonActiveSlides.forEach((slide) => {
+      expect(slide.getAttribute("inert")).toBe("true");
+      expect(slide.getAttribute("aria-hidden")).toBe("true");
+    });
   });
 
   test("scrollToActiveSlide calls gsap.to with expected params", () => {

--- a/app/src/components/slidesContainer.spec.js
+++ b/app/src/components/slidesContainer.spec.js
@@ -126,6 +126,11 @@ describe("SlidesContainer", () => {
     });
   });
 
+  test("a11y: when scroll completes, active slide is focused", () => {
+    slidesContainer.handleScrollComplete();
+    expect(document.activeElement).toBe(slidesContainer.activeSlide);
+  });
+
   test("checks prefers-reduced-motion media query", () => {
     mockMatchMedia.mockImplementation(() => ({ matches: true }));
     slidesContainer = new SlidesContainer({

--- a/app/src/hbs_templates/main.hbs
+++ b/app/src/hbs_templates/main.hbs
@@ -23,7 +23,6 @@
   <div class="slides" aria-live="polite">
     <div
       class="slide"
-      tabindex="-1"
       role="group"
       {{!-- TODO: add translations for aria-roledescription --}}
       aria-roledescription="slide"
@@ -55,7 +54,6 @@
 
     <div
       class="slide"
-      tabindex="-1"
       id="slide-2"
       role="group"
       {{!-- TODO: add translations for aria-roledescription --}}
@@ -72,7 +70,6 @@
 
     <div
       class="slide"
-      tabindex="-1"
       id="slide-3"
       role="group"
       {{!-- TODO: add translations for aria-roledescription --}}
@@ -89,7 +86,6 @@
 
     <div
       class="slide"
-      tabindex="-1"
       id="slide-4"
       role="group"
       {{!-- TODO: add translations for aria-roledescription --}}
@@ -123,7 +119,6 @@
 
     <div
       class="slide"
-      tabindex="-1"
       id="slide-5"
       role="group"
       {{!-- TODO: add translations for aria-roledescription --}}
@@ -150,7 +145,6 @@
 
     <div
       class="slide"
-      tabindex="-1"
       id="slide-6"
       role="group"
       {{!-- TODO: add translations for aria-roledescription --}}
@@ -176,7 +170,6 @@
 
     <div
       class="slide"
-      tabindex="-1"
       id="slide-7"
       role="group"
       {{!-- TODO: add translations for aria-roledescription --}}
@@ -206,7 +199,6 @@
 
     <div
       class="slide"
-      tabindex="-1"
       id="slide-8"
       role="group"
       {{!-- TODO: add translations for aria-roledescription --}}
@@ -243,7 +235,6 @@
 
     <div
       class="slide"
-      tabindex="-1"
       id="slide-9"
       role="group"
       {{!-- TODO: add translations for aria-roledescription --}}

--- a/app/src/hbs_templates/main.hbs
+++ b/app/src/hbs_templates/main.hbs
@@ -23,6 +23,7 @@
   <div class="slides" aria-live="polite">
     <div
       class="slide"
+      tabindex="-1"
       role="group"
       {{!-- TODO: add translations for aria-roledescription --}}
       aria-roledescription="slide"
@@ -54,6 +55,7 @@
 
     <div
       class="slide"
+      tabindex="-1"
       id="slide-2"
       role="group"
       {{!-- TODO: add translations for aria-roledescription --}}
@@ -70,6 +72,7 @@
 
     <div
       class="slide"
+      tabindex="-1"
       id="slide-3"
       role="group"
       {{!-- TODO: add translations for aria-roledescription --}}
@@ -86,6 +89,7 @@
 
     <div
       class="slide"
+      tabindex="-1"
       id="slide-4"
       role="group"
       {{!-- TODO: add translations for aria-roledescription --}}
@@ -119,6 +123,7 @@
 
     <div
       class="slide"
+      tabindex="-1"
       id="slide-5"
       role="group"
       {{!-- TODO: add translations for aria-roledescription --}}
@@ -145,6 +150,7 @@
 
     <div
       class="slide"
+      tabindex="-1"
       id="slide-6"
       role="group"
       {{!-- TODO: add translations for aria-roledescription --}}
@@ -170,6 +176,7 @@
 
     <div
       class="slide"
+      tabindex="-1"
       id="slide-7"
       role="group"
       {{!-- TODO: add translations for aria-roledescription --}}
@@ -199,6 +206,7 @@
 
     <div
       class="slide"
+      tabindex="-1"
       id="slide-8"
       role="group"
       {{!-- TODO: add translations for aria-roledescription --}}
@@ -235,6 +243,7 @@
 
     <div
       class="slide"
+      tabindex="-1"
       id="slide-9"
       role="group"
       {{!-- TODO: add translations for aria-roledescription --}}

--- a/app/src/utils/initApp.js
+++ b/app/src/utils/initApp.js
@@ -72,7 +72,7 @@ export default function initApp() {
   registry.add(
     "slidesContainer",
     new SlidesContainer({
-      element: document.querySelector(".slides-container"),
+      element: document.querySelector(".slides"),
       store,
     })
   );

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -4886,10 +4886,10 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-gsap@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/gsap/-/gsap-3.6.0.tgz#925f25370c698ce0f6ea563522da8f6b5ed21b0a"
-  integrity sha512-0P3syv1TmYr+A/VZ8UMFzw+s0XoaKSzzDFs8NqkXiJTXI4E/VTi0zRjPgxaPBpiUPPycgRnFjLDe0Tb4dRRf+w==
+gsap@^3.12.2:
+  version "3.12.4"
+  resolved "https://registry.yarnpkg.com/gsap/-/gsap-3.12.4.tgz#b9383fe16bb14968e2c7db2a7c0e308edf551e7b"
+  integrity sha512-1ByAq8dD0W4aBZ/JArgaQvc0gyUfkGkP8mgAQa0qZGdpOKlSOhOf+WNXjoLimKaKG3Z4Iu6DKZtnyszqQeyqWQ==
 
 handle-thing@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
PR #125 which made the homepage's slides and slides navigation accessible also broke the smooth scroll animation that happens when navigating between slides (when a user does not have the "prefers-reduced-motion" setting enabled in their device). 

This PR fixes that issue / restores the smooth scroll animation using [GSAP](https://gsap.com/docs/v3/GSAP/gsap.to()/).

Upgrades the GSAP library dependancy to version `13.12.2`