### PR TITLE
use carto sql api v3

### DIFF
--- a/app/src/action_creators/rentStabilizedActions.js
+++ b/app/src/action_creators/rentStabilizedActions.js
@@ -1,6 +1,6 @@
 import "cross-fetch/polyfill";
 
-import { cartoAccount } from "../constants/config";
+import { cartoAPIv3BaseURL, cartoApiKey } from "../constants/config";
 import { rentStabilizedBblSql } from "../utils/sql";
 import * as types from "../constants/actionTypes";
 
@@ -23,11 +23,21 @@ export const rentStabilizedReset = () => ({
 });
 
 export const fetchRentStabilized = (bbl) => (dispatch) => {
+  const headers = new Headers();
+  headers.append("Authorization", `Bearer ${cartoApiKey}`);
+
+  const requestOptions = {
+    method: "GET",
+    headers: headers,
+    redirect: "follow",
+  };
+
   dispatch(rentStabilizedRequest());
   return fetch(
-    `https://${cartoAccount}.cartodb.com/api/v2/sql?q=${window.encodeURIComponent(
+    `${cartoAPIv3BaseURL}/v3/sql/carto_dw/query?q=${window.encodeURIComponent(
       rentStabilizedBblSql(bbl)
-    )}`
+    )}`,
+    requestOptions
   )
     .then((res) => {
       if (res.ok) {

--- a/app/src/action_creators/tenantsRightsGroupsActions.js
+++ b/app/src/action_creators/tenantsRightsGroupsActions.js
@@ -1,6 +1,6 @@
 import "cross-fetch/polyfill";
 import * as types from "../constants/actionTypes";
-import { cartoAccount } from "../constants/config";
+import { cartoApiKey, cartoAPIv3BaseURL } from "../constants/config";
 import { tenantsRightsGroupsSql } from "../utils/sql";
 
 export const tenantsRightsGroupsRequest = () => ({
@@ -22,11 +22,21 @@ export const tenantsRightsGroupsReset = () => ({
 });
 
 export const fetchTenantsRightsGroups = ({ lon, lat }) => (dispatch) => {
+  const headers = new Headers();
+  headers.append("Authorization", `Bearer ${cartoApiKey}`);
+
+  const requestOptions = {
+    method: "GET",
+    headers: headers,
+    redirect: "follow",
+  };
+
   dispatch(tenantsRightsGroupsRequest());
   return fetch(
-    `https://${cartoAccount}.cartodb.com/api/v2/sql?q=${window.encodeURIComponent(
+    `${cartoAPIv3BaseURL}/v3/sql/carto_dw/query?q=${window.encodeURIComponent(
       tenantsRightsGroupsSql({ lon, lat })
-    )}`
+    )}`,
+    requestOptions
   )
     .then((res) => {
       if (res.ok) {

--- a/app/src/components/verifyRentStabilized.js
+++ b/app/src/components/verifyRentStabilized.js
@@ -23,7 +23,11 @@ export class VerifyRentStabilized extends Component {
   }
 
   updateMessage() {
-    if (this.match && this.match.total_rows > 0) {
+    if (
+      this.match &&
+      Array.isArray(this.match.rows) &&
+      this.match.rows.length
+    ) {
       this.msgYes.classList.remove("hidden");
       this.msgNo.classList.add("hidden");
       logAddressRS(this.match.rows[0].bbl);

--- a/app/src/constants/config.js
+++ b/app/src/constants/config.js
@@ -2,3 +2,11 @@
 export const cartoAccount = "chenrick";
 export const rentStabilizedTable = "mappluto_likely_rs_2020_v8";
 export const geosearchApiVersion = "v2";
+
+export const cartoAPIv3BaseURL = "https://gcp-us-east1.api.carto.com";
+export const cartoV3RentStabilizedTableName =
+  "shared.mappluto_likely_rs_2020_v8";
+
+// NOTE: this API key is restricted for use on the domain https://amirentstabilized.com
+export const cartoApiKey =
+  "eyJhbGciOiJIUzI1NiJ9.eyJhIjoiYWNfd3cwaDFiczgiLCJqdGkiOiIyOTVmZGRkNiJ9.w6GC-oesQEl5HerTbTlZWxFb8-c8iX7F0NAG9pCunu0";

--- a/app/src/constants/config.js
+++ b/app/src/constants/config.js
@@ -6,6 +6,8 @@ export const geosearchApiVersion = "v2";
 export const cartoAPIv3BaseURL = "https://gcp-us-east1.api.carto.com";
 export const cartoV3RentStabilizedTableName =
   "shared.mappluto_likely_rs_2020_v8";
+export const cartoV3TenantsRightsServiceAreasTable =
+  "shared.nyc_tenants_rights_service_areas";
 
 // NOTE: this API key is restricted for use on the domain https://amirentstabilized.com
 export const cartoApiKey =

--- a/app/src/utils/sql.js
+++ b/app/src/utils/sql.js
@@ -1,20 +1,23 @@
-import { rentStabilizedTable } from "../constants/config";
+import {
+  rentStabilizedTable,
+  cartoV3RentStabilizedTableName,
+} from "../constants/config";
 
 export const rentStabilizedBblSql = (bbl) =>
-  `SELECT bbl FROM ${rentStabilizedTable} WHERE bbl = ${bbl}`;
+  `SELECT bbl FROM ${cartoV3RentStabilizedTableName} WHERE bbl = ${bbl}`;
 
 export const mapsApiSql = () =>
   `SELECT the_geom_webmercator FROM ${rentStabilizedTable}`;
 
 export const tenantsRightsGroupsSql = ({ lon, lat }) =>
-  `SELECT 
-    name, 
-    full_address, 
-    email, 
-    phone, 
-    description, 
-    service_area, 
-    website_url 
+  `SELECT
+    name,
+    full_address,
+    email,
+    phone,
+    description,
+    service_area,
+    website_url
   FROM nyc_tenants_rights_service_areas
   WHERE ST_Contains(
     the_geom,

--- a/app/src/utils/sql.js
+++ b/app/src/utils/sql.js
@@ -1,6 +1,7 @@
 import {
   rentStabilizedTable,
   cartoV3RentStabilizedTableName,
+  cartoV3TenantsRightsServiceAreasTable,
 } from "../constants/config";
 
 export const rentStabilizedBblSql = (bbl) =>
@@ -18,11 +19,10 @@ export const tenantsRightsGroupsSql = ({ lon, lat }) =>
     description,
     service_area,
     website_url
-  FROM nyc_tenants_rights_service_areas
+  FROM ${cartoV3TenantsRightsServiceAreasTable}
   WHERE ST_Contains(
-    the_geom,
-    ST_GeomFromText(
-      'POINT(' || ${lon} || ' ' || ${lat} ||  ')',
-      4326
+    geom,
+    ST_GeogFromText(
+      'POINT(' || ${lon} || ' ' || ${lat} ||  ')'
     )
   )`;

--- a/app/src/utils/sql.spec.js
+++ b/app/src/utils/sql.spec.js
@@ -1,11 +1,14 @@
 import * as sql from "./sql";
-import { rentStabilizedTable } from "../constants/config";
+import {
+  rentStabilizedTable,
+  cartoV3RentStabilizedTableName,
+} from "../constants/config";
 
 describe("utils/sql", () => {
   test("rentStabilizedBblSql", () => {
     const result = sql.rentStabilizedBblSql("999999999");
     expect(result).toBe(
-      `SELECT bbl FROM ${rentStabilizedTable} WHERE bbl = 999999999`
+      `SELECT bbl FROM ${cartoV3RentStabilizedTableName} WHERE bbl = 999999999`
     );
   });
 


### PR DESCRIPTION
Addresses #147 

- updates the rent stabilized data fetch to use the new Carto endpoint
- updates the tenants rights data fetch to use the new Carto endpoint
- updates the rent stabilized SQL to use the new table name
- updates the tenants rights SQL to use the new table name & BigQuery spatial query syntax