### PR TITLE
remove dependency cross-fetch

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -119,7 +119,6 @@
   },
   "dependencies": {
     "core-js": "^3.6.4",
-    "cross-fetch": "^3.1.5",
     "d3-geo": "^2.0.1",
     "d3-tile": "^1.0.0",
     "gsap": "^3.12.2",

--- a/app/src/action_creators/addressGeocodeActions.js
+++ b/app/src/action_creators/addressGeocodeActions.js
@@ -1,4 +1,3 @@
-import "cross-fetch/polyfill";
 import * as types from "../constants/actionTypes";
 import { geosearchApiVersion } from "../constants/config";
 

--- a/app/src/action_creators/rentStabilizedActions.js
+++ b/app/src/action_creators/rentStabilizedActions.js
@@ -1,5 +1,3 @@
-import "cross-fetch/polyfill";
-
 import { cartoAccount } from "../constants/config";
 import { rentStabilizedBblSql } from "../utils/sql";
 import * as types from "../constants/actionTypes";

--- a/app/src/action_creators/tenantsRightsGroupsActions.js
+++ b/app/src/action_creators/tenantsRightsGroupsActions.js
@@ -1,4 +1,3 @@
-import "cross-fetch/polyfill";
 import * as types from "../constants/actionTypes";
 import { cartoAccount } from "../constants/config";
 import { tenantsRightsGroupsSql } from "../utils/sql";

--- a/app/src/components/mapTileLayers.js
+++ b/app/src/components/mapTileLayers.js
@@ -1,4 +1,3 @@
-import "cross-fetch/polyfill";
 import * as d3Tile from "d3-tile";
 import { mapsApiSql } from "../utils/sql";
 import { cartoAccount } from "../constants/config";

--- a/app/src/utils/translate.js
+++ b/app/src/utils/translate.js
@@ -1,4 +1,3 @@
-import "cross-fetch/polyfill";
 import { getPageJsBundle } from "./pageBundle";
 import { LANGS, LOCALES_JSON_DIR } from "../constants/locales";
 import { logException, handleErrorObj } from "./logging";

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3056,7 +3056,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-fetch@^3.0.4, cross-fetch@^3.1.5:
+cross-fetch@^3.0.4:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==


### PR DESCRIPTION
The native `fetch` API is well [supported in modern browsers now](https://caniuse.com/fetch), so no need to use a polyfill.