### PR TITLE
update search result map likely rs map layer

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -117,6 +117,7 @@
     "webpack-dev-server": "^3.11.2"
   },
   "dependencies": {
+    "@turf/rewind": "^7.2.0",
     "core-js": "^3.6.4",
     "d3-geo": "^2.0.1",
     "d3-tile": "^1.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -12,7 +12,7 @@
   "main": "src/index.js",
   "scripts": {
     "start": "webpack-dev-server --mode=development --env.NODE_ENV=development",
-    "start:preloaded-state": "npm start -- --env.USE_PRELOADED_STATE=true",
+    "start:preloaded-state": "npm start -- --env.USE_PRELOADED_STATE=true --env.USE_REDUX_LOGGER=true",
     "start:prod": "serve dist",
     "webpack:debug": "webpack --debug=true --display-error-details=true --verbose=true --mode=development --env.NODE_ENV=development --env.USE_REDUX_LOGGER=true",
     "prod": "webpack --mode=production --env.NODE_ENV=production",

--- a/app/src/action_creators/rentStabilizedActions.js
+++ b/app/src/action_creators/rentStabilizedActions.js
@@ -1,5 +1,6 @@
-import { cartoAPIv3BaseURL, cartoApiKey } from "../constants/config";
+import { cartoAPIv3BaseURL } from "../constants/config";
 import { rentStabilizedBblSql } from "../utils/sql";
+import { cartoSqlApiAuthOptions } from "../utils/cartoSqlApiAuth";
 import * as types from "../constants/actionTypes";
 
 export const rentStabilizedRequest = () => ({
@@ -21,16 +22,10 @@ export const rentStabilizedReset = () => ({
 });
 
 export const fetchRentStabilized = (bbl) => (dispatch) => {
-  const headers = new Headers();
-  headers.append("Authorization", `Bearer ${cartoApiKey}`);
-
-  const requestOptions = {
-    method: "GET",
-    headers: headers,
-    redirect: "follow",
-  };
+  const requestOptions = cartoSqlApiAuthOptions();
 
   dispatch(rentStabilizedRequest());
+
   return fetch(
     `${cartoAPIv3BaseURL}/v3/sql/carto_dw/query?q=${window.encodeURIComponent(
       rentStabilizedBblSql(bbl)

--- a/app/src/action_creators/rentStabilizedActions.js
+++ b/app/src/action_creators/rentStabilizedActions.js
@@ -21,15 +21,19 @@ export const rentStabilizedReset = () => ({
   type: types.RentStabilizedReset,
 });
 
+/**
+ * Async action creator that makes a GET request the Carto SQL API to query taxlots identified as likely rent-stabilized (RS)
+ * @param {number} bbl the "Borough,Block,Lot" number of the NYC geocoded address to search for
+ * @returns {Promise<Error|object>}
+ */
 export const fetchRentStabilized = (bbl) => (dispatch) => {
+  const url = `${cartoAPIv3BaseURL}/v3/sql/carto_dw/query`;
   const requestOptions = cartoSqlApiAuthOptions();
 
   dispatch(rentStabilizedRequest());
 
   return fetch(
-    `${cartoAPIv3BaseURL}/v3/sql/carto_dw/query?q=${window.encodeURIComponent(
-      rentStabilizedBblSql(bbl)
-    )}`,
+    `${url}?q=${window.encodeURIComponent(rentStabilizedBblSql(bbl))}`,
     requestOptions
   )
     .then((res) => {

--- a/app/src/action_creators/rentStabilizedActions.js
+++ b/app/src/action_creators/rentStabilizedActions.js
@@ -1,6 +1,6 @@
 import { cartoAPIv3BaseURL } from "../constants/config";
 import { rentStabilizedBblSql } from "../utils/sql";
-import { cartoSqlApiAuthOptions } from "../utils/cartoSqlApiAuth";
+import { getCartoSqlApiAuthOptions } from "../utils/cartoSqlApiAuth";
 import * as types from "../constants/actionTypes";
 
 export const rentStabilizedRequest = () => ({
@@ -28,7 +28,7 @@ export const rentStabilizedReset = () => ({
  */
 export const fetchRentStabilized = (bbl) => (dispatch) => {
   const url = `${cartoAPIv3BaseURL}/v3/sql/carto_dw/query`;
-  const requestOptions = cartoSqlApiAuthOptions();
+  const requestOptions = getCartoSqlApiAuthOptions();
 
   dispatch(rentStabilizedRequest());
 

--- a/app/src/action_creators/rentStabilizedGeoJsonActions.js
+++ b/app/src/action_creators/rentStabilizedGeoJsonActions.js
@@ -1,0 +1,55 @@
+import * as types from "../constants/actionTypes";
+import { cartoAPIv3BaseURL } from "../constants/config";
+import { cartoSqlApiAuthOptions } from "../utils/cartoSqlApiAuth";
+import { rentStabilizedGeomSql } from "../utils/sql";
+
+export const rentStabilizedGeoJsonRequest = () => ({
+  type: types.RentStabilizedGeoJsonRequest,
+});
+
+export const rentStabilizedGeoJsonSuccess = (payload) => ({
+  type: types.RentStabilizedGeoJsonSuccess,
+  payload,
+});
+
+export const rentStabilizedGeoJsonFailure = (error) => ({
+  type: types.RentStabilizedGeoJsonFailure,
+  error,
+});
+
+export const rentStabilizedGeoJsonReset = () => ({
+  type: types.RentStabilizedGeoJsonReset,
+});
+
+/**
+ * Async action creator that makes a GET request the Carto SQL API to query GeoJSON polygons for likely RS taxlots near the RS search result's coordinates so that they may be rendered on the map
+ * @param {object} lonLat
+ * @param {number} object.lon - longitude of likely rs search result
+ * @param {number} object.lat - latitude of likely rs search result
+ * @returns {Promise<Error|object>}
+ */
+export const fetchRentStabilizedGeoJSON = ({ lon, lat }) => (dispatch) => {
+  const url = `${cartoAPIv3BaseURL}/v3/sql/carto_dw/query`;
+  const requestOptions = cartoSqlApiAuthOptions();
+
+  dispatch(rentStabilizedGeoJsonRequest());
+
+  return fetch(
+    `${url}?q=${encodeURIComponent(rentStabilizedGeomSql({ lon, lat }))}`,
+    requestOptions
+  )
+    .then((res) => {
+      if (res.ok) {
+        return res.json();
+      }
+      throw new Error("Problem fetching rent stabilized geojson");
+    })
+    .then((json) => {
+      dispatch(rentStabilizedGeoJsonSuccess(json));
+      return json;
+    })
+    .catch((error) => {
+      dispatch(rentStabilizedGeoJsonFailure(error));
+      return error;
+    });
+};

--- a/app/src/action_creators/rentStabilizedGeoJsonActions.js
+++ b/app/src/action_creators/rentStabilizedGeoJsonActions.js
@@ -52,9 +52,9 @@ export const fetchRentStabilizedGeoJSON = ({ lon, lat }) => (dispatch) => {
       }
       return [];
     })
-    .then((json) => {
-      dispatch(rentStabilizedGeoJsonSuccess(json));
-      return json;
+    .then((geojson) => {
+      dispatch(rentStabilizedGeoJsonSuccess(geojson));
+      return geojson;
     })
     .catch((error) => {
       dispatch(rentStabilizedGeoJsonFailure(error));

--- a/app/src/action_creators/rentStabilizedGeoJsonActions.js
+++ b/app/src/action_creators/rentStabilizedGeoJsonActions.js
@@ -2,6 +2,7 @@ import * as types from "../constants/actionTypes";
 import { cartoAPIv3BaseURL } from "../constants/config";
 import { cartoSqlApiAuthOptions } from "../utils/cartoSqlApiAuth";
 import { rentStabilizedGeomSql } from "../utils/sql";
+import { parseTransformRsGeomQueryResult } from "../utils/geoUtils";
 
 export const rentStabilizedGeoJsonRequest = () => ({
   type: types.RentStabilizedGeoJsonRequest,
@@ -43,6 +44,13 @@ export const fetchRentStabilizedGeoJSON = ({ lon, lat }) => (dispatch) => {
         return res.json();
       }
       throw new Error("Problem fetching rent stabilized geojson");
+    })
+    .then((json) => {
+      if (Array.isArray(json?.rows) && json.rows.length) {
+        const transformed = parseTransformRsGeomQueryResult(json.rows);
+        return transformed;
+      }
+      return [];
     })
     .then((json) => {
       dispatch(rentStabilizedGeoJsonSuccess(json));

--- a/app/src/action_creators/rentStabilizedGeoJsonActions.js
+++ b/app/src/action_creators/rentStabilizedGeoJsonActions.js
@@ -1,6 +1,6 @@
 import * as types from "../constants/actionTypes";
 import { cartoAPIv3BaseURL } from "../constants/config";
-import { cartoSqlApiAuthOptions } from "../utils/cartoSqlApiAuth";
+import { getCartoSqlApiAuthOptions } from "../utils/cartoSqlApiAuth";
 import { rentStabilizedGeomSql } from "../utils/sql";
 import { parseTransformRsGeomQueryResult } from "../utils/geoUtils";
 
@@ -31,7 +31,7 @@ export const rentStabilizedGeoJsonReset = () => ({
  */
 export const fetchRentStabilizedGeoJSON = ({ lon, lat }) => (dispatch) => {
   const url = `${cartoAPIv3BaseURL}/v3/sql/carto_dw/query`;
-  const requestOptions = cartoSqlApiAuthOptions();
+  const requestOptions = getCartoSqlApiAuthOptions();
 
   dispatch(rentStabilizedGeoJsonRequest());
 

--- a/app/src/action_creators/searchRentStabilizedActions.js
+++ b/app/src/action_creators/searchRentStabilizedActions.js
@@ -9,6 +9,7 @@ import {
 import { goToSlideIdx } from "./slidesActions";
 import { delay } from "../utils/delay";
 import { RS_SEARCH_DELAY_MS } from "../constants/app";
+import { fetchRentStabilizedGeoJSON } from "./rentStabilizedGeoJsonActions";
 
 export const ERROR_ADDRESS_NOT_FOUND = "Address search result not found";
 export const ERROR_MISSING_BBL =
@@ -42,9 +43,10 @@ export function getBBL(feature) {
  * This is a compound action creator that handles:
  * 1. geocoding an address inputted by the user
  * 2. looking up the result in the rent stabilized data
- * 3. pausing so the cute animation can play
- * 4. going to the "you might/might not be rent stabilized" slide
- * 5. OR going back to the address search slide if an error occurs
+ * 3. querying geojson of rent stabilized properties nearby the search result to display in the map
+ * 4. pausing so the cute animation can play
+ * 5. going to the "you might/might not be rent stabilized" slide
+ * 6. OR going back to the address search slide if an error occurs
  */
 export const searchRentStabilized = (addressInfo) => async (dispatch) => {
   try {
@@ -69,6 +71,14 @@ export const searchRentStabilized = (addressInfo) => async (dispatch) => {
     );
 
     validateRS(rsResult);
+
+    if (
+      Array.isArray(searchResultFeature?.geometry?.coordinates) &&
+      searchResultFeature.geometry.coordinates.length
+    ) {
+      const [lon, lat] = searchResultFeature.geometry.coordinates;
+      await dispatch(fetchRentStabilizedGeoJSON({ lon, lat }));
+    }
 
     await delay(RS_SEARCH_DELAY_MS);
     dispatch(goToSlideIdx(3));

--- a/app/src/action_creators/searchRentStabilizedActions.js
+++ b/app/src/action_creators/searchRentStabilizedActions.js
@@ -63,9 +63,11 @@ export const searchRentStabilized = (addressInfo) => async (dispatch) => {
 
     validateSearchResult(searchResult);
 
+    const searchResultFeature = searchResult.features[0];
     const rsResult = await dispatch(
-      fetchRentStabilized(getBBL(searchResult.features[0]))
+      fetchRentStabilized(getBBL(searchResultFeature))
     );
+
     validateRS(rsResult);
 
     await delay(RS_SEARCH_DELAY_MS);

--- a/app/src/action_creators/tenantsRightsGroupsActions.js
+++ b/app/src/action_creators/tenantsRightsGroupsActions.js
@@ -1,6 +1,6 @@
 import * as types from "../constants/actionTypes";
 import { cartoAPIv3BaseURL } from "../constants/config";
-import { cartoSqlApiAuthOptions } from "../utils/cartoSqlApiAuth";
+import { getCartoSqlApiAuthOptions } from "../utils/cartoSqlApiAuth";
 import { tenantsRightsGroupsSql } from "../utils/sql";
 
 export const tenantsRightsGroupsRequest = () => ({
@@ -22,7 +22,7 @@ export const tenantsRightsGroupsReset = () => ({
 });
 
 export const fetchTenantsRightsGroups = ({ lon, lat }) => (dispatch) => {
-  const requestOptions = cartoSqlApiAuthOptions();
+  const requestOptions = getCartoSqlApiAuthOptions();
 
   dispatch(tenantsRightsGroupsRequest());
 

--- a/app/src/action_creators/tenantsRightsGroupsActions.js
+++ b/app/src/action_creators/tenantsRightsGroupsActions.js
@@ -1,5 +1,6 @@
 import * as types from "../constants/actionTypes";
-import { cartoApiKey, cartoAPIv3BaseURL } from "../constants/config";
+import { cartoAPIv3BaseURL } from "../constants/config";
+import { cartoSqlApiAuthOptions } from "../utils/cartoSqlApiAuth";
 import { tenantsRightsGroupsSql } from "../utils/sql";
 
 export const tenantsRightsGroupsRequest = () => ({
@@ -21,16 +22,10 @@ export const tenantsRightsGroupsReset = () => ({
 });
 
 export const fetchTenantsRightsGroups = ({ lon, lat }) => (dispatch) => {
-  const headers = new Headers();
-  headers.append("Authorization", `Bearer ${cartoApiKey}`);
-
-  const requestOptions = {
-    method: "GET",
-    headers: headers,
-    redirect: "follow",
-  };
+  const requestOptions = cartoSqlApiAuthOptions();
 
   dispatch(tenantsRightsGroupsRequest());
+
   return fetch(
     `${cartoAPIv3BaseURL}/v3/sql/carto_dw/query?q=${window.encodeURIComponent(
       tenantsRightsGroupsSql({ lon, lat })

--- a/app/src/components/mapLikelyRsLayer.js
+++ b/app/src/components/mapLikelyRsLayer.js
@@ -1,0 +1,49 @@
+import { rentStabilizedGeomSql } from "../utils/sql";
+import { cartoAPIv3BaseURL, cartoApiKey } from "../constants/config";
+import { logException, handleErrorObj } from "../utils/logging";
+
+export class MapLikelyRsLayer {
+  constructor(searchResultMap) {
+    this.searchResultMap = searchResultMap;
+    this.dimensions = searchResultMap.dimensions;
+    this.projection = searchResultMap.projection;
+    this._likelyRsGeoJson = null;
+    this.init = this.init.bind(this);
+
+    this.fetchLikelyRsGeoJson = this.fetchLikelyRsGeoJson.bind(this);
+
+    this.init();
+  }
+
+  async init() {
+    console.log("MapLikelyRsLayer init");
+    // TODO: delete these two lines, only a test
+    await this.fetchLikelyRsGeoJson([-73.95757, 40.658]);
+    console.log(this._likelyRsGeoJson);
+  }
+
+  async renderLikelyRsLayer() {}
+
+  /**
+   *
+   * @param {[number, number]} coords [lon, lat]
+   */
+  async fetchLikelyRsGeoJson(coords) {
+    const url = `${cartoAPIv3BaseURL}/v3/sql/carto_dw/query`;
+    const headers = new Headers();
+    headers.append("Authorization", `Bearer ${cartoApiKey}`);
+
+    const requestOptions = {
+      method: "GET",
+      headers: headers,
+      redirect: "follow",
+    };
+    const res = await fetch(
+      `${url}?q=${encodeURIComponent(
+        rentStabilizedGeomSql({ lon: coords[0], lat: coords[1] })
+      )}`,
+      requestOptions
+    );
+    this._likelyRsGeoJson = await res.json();
+  }
+}

--- a/app/src/components/mapLikelyRsLayer.js
+++ b/app/src/components/mapLikelyRsLayer.js
@@ -85,12 +85,12 @@ export class MapLikelyRsLayer {
       ?.map(
         (feature) =>
           `<path
-						stroke=${LAYER_STYLES.strokeColor}
-						stroke-width="${LAYER_STYLES.strokeWidth}"
-						fill=${LAYER_STYLES.fillColor}
-						fill-opacity="${LAYER_STYLES.fillOpacity}"
-						d="${this._pathGenerator(feature)}"
-					/>`
+            stroke=${LAYER_STYLES.strokeColor}
+            stroke-width="${LAYER_STYLES.strokeWidth}"
+            fill=${LAYER_STYLES.fillColor}
+            fill-opacity="${LAYER_STYLES.fillOpacity}"
+            d="${this._pathGenerator(feature)}"
+          />`
       )
       .join("\n");
   }

--- a/app/src/components/mapLikelyRsLayer.js
+++ b/app/src/components/mapLikelyRsLayer.js
@@ -3,6 +3,11 @@ import { rentStabilizedGeomSql } from "../utils/sql";
 import { cartoAPIv3BaseURL, cartoApiKey } from "../constants/config";
 import { logException, handleErrorObj } from "../utils/logging";
 
+/**
+ * class that handles rendering the SearchResultMap's likely rent-stabilized data layer of SVG path elements
+ * - queries the Carto SQL API for a GeoJSON representation of likely RS properties
+ * - transforms GeoJSON to SVG path elements suitable for rendering in the appropriate map layer
+ */
 export class MapLikelyRsLayer {
   constructor(searchResultMap) {
     this.searchResultMap = searchResultMap;
@@ -28,7 +33,10 @@ export class MapLikelyRsLayer {
     this._pathGenerator = geoPath(this.projection);
   }
 
-  /** handles rendering the SVG map's likely RS polygon map layer */
+  /**
+   * handles rendering the SVG map's likely RS polygon map layer
+   * @returns {Promise<string | undefined>}
+   */
   async renderMapLikelyRsLayer() {
     try {
       await this.fetchLikelyRsGeoJson(this.searchResultMap.center);

--- a/app/src/components/mapLikelyRsLayer.js
+++ b/app/src/components/mapLikelyRsLayer.js
@@ -4,6 +4,14 @@ import { rentStabilizedGeomSql } from "../utils/sql";
 import { cartoAPIv3BaseURL, cartoApiKey } from "../constants/config";
 import { logException, handleErrorObj } from "../utils/logging";
 
+/** likely rs svg path styles */
+const LAYER_STYLES = {
+  strokeWidth: 0.7,
+  strokeColor: "#fff",
+  fillColor: "#ff6600",
+  fillOpacity: 0.7,
+};
+
 /**
  * class that handles rendering the SearchResultMap's likely rent-stabilized data layer of SVG path elements
  * - queries the Carto SQL API for a GeoJSON representation of likely RS properties
@@ -61,17 +69,14 @@ export class MapLikelyRsLayer {
    * @returns {string}
    */
   renderGeoJsonPaths(features) {
-    // TODO: stroke color = #ffffff
-    // TODO: fill color = #ff6600
     return features
       ?.map(
         (feature) =>
           `<path
-						clip-path="url(#clip-path)"
-						stroke="#fff"
-						stroke-width="0.7"
-						fill="#ff6600"
-						fill-opacity="0.7"
+						stroke=${LAYER_STYLES.strokeColor}
+						stroke-width="${LAYER_STYLES.strokeWidth}"
+						fill=${LAYER_STYLES.fillColor}
+						fill-opacity="${LAYER_STYLES.fillOpacity}"
 						d="${this._pathGenerator(feature)}"
 					/>`
       )

--- a/app/src/components/mapLikelyRsLayer.js
+++ b/app/src/components/mapLikelyRsLayer.js
@@ -116,6 +116,7 @@ export class MapLikelyRsLayer {
   }
 
   /**
+   * TODO: move this code to a redux action creator!
    * makes the SQL API call to query GeoJSON geometries of likely RS properties within the proximity of search result coordinates
    * @param {[number, number]} coords [lon, lat]
    */

--- a/app/src/components/mapLikelyRsLayer.js
+++ b/app/src/components/mapLikelyRsLayer.js
@@ -21,18 +21,13 @@ const LAYER_STYLES = {
  */
 
 /**
- * class that handles rendering the SearchResultMap's likely rent-stabilized data layer of SVG path elements
- * - queries the Carto SQL API for a GeoJSON representation of likely RS properties
- * - transforms GeoJSON to SVG path elements suitable for rendering in the appropriate map layer
+ * class that handles creating the SearchResultMap's likely rent-stabilized data layer of SVG path elements
  */
 export class MapLikelyRsLayer {
   constructor(searchResultMap) {
     this.searchResultMap = searchResultMap;
     this.dimensions = searchResultMap.dimensions;
     this.projection = searchResultMap.projection;
-
-    /** @type {null | Row[]} Carto SQL API result of GeoJSON geometries of likely RS properties */
-    this._likelyRsGeoJson = null;
 
     /** @type {null | ReturnType<geoPath>} d3-geo SVG path generator */
     this._pathGenerator = null;

--- a/app/src/components/mapLikelyRsLayer.js
+++ b/app/src/components/mapLikelyRsLayer.js
@@ -1,4 +1,5 @@
 import { geoPath } from "d3-geo";
+import { rewind } from "@turf/rewind";
 import { rentStabilizedGeomSql } from "../utils/sql";
 import { cartoAPIv3BaseURL, cartoApiKey } from "../constants/config";
 import { logException, handleErrorObj } from "../utils/logging";
@@ -65,14 +66,14 @@ export class MapLikelyRsLayer {
     return features
       ?.map(
         (feature) =>
-          `<path 
-          clip-path="url(#clip-path)"
-          stroke="#000"
-          stroke-width="0.7"
-          fill="none"
-          fill-opacity="0.7"
-          d="${this._pathGenerator(feature)}"
-        />`
+          `<path
+						clip-path="url(#clip-path)"
+						stroke="#fff"
+						stroke-width="0.7"
+						fill="#ff6600"
+						fill-opacity="0.7"
+						d="${this._pathGenerator(feature)}"
+					/>`
       )
       .join("\n");
   }
@@ -83,12 +84,16 @@ export class MapLikelyRsLayer {
    * @returns {any[]}
    */
   processQueryResult(rows) {
-    // TODO "rewind" order of coordinates to fix geojson rendering
-    const features = rows.map((d) => ({
-      type: "Feature",
-      properties: {},
-      geometry: JSON.parse(d?.geojson || "{}"),
-    }));
+    const features = rows.map((d) =>
+      rewind(
+        {
+          type: "Feature",
+          properties: {},
+          geometry: JSON.parse(d?.geojson || "{}"),
+        },
+        { reverse: true }
+      )
+    );
     return features;
   }
 

--- a/app/src/components/mapLikelyRsLayer.js
+++ b/app/src/components/mapLikelyRsLayer.js
@@ -1,7 +1,8 @@
 import { geoPath } from "d3-geo";
 import { rewind } from "@turf/rewind";
 import { rentStabilizedGeomSql } from "../utils/sql";
-import { cartoAPIv3BaseURL, cartoApiKey } from "../constants/config";
+import { cartoSqlApiAuthOptions } from "../utils/cartoSqlApiAuth";
+import { cartoAPIv3BaseURL } from "../constants/config";
 import { logException, handleErrorObj } from "../utils/logging";
 
 /** likely rs svg path styles */
@@ -120,20 +121,15 @@ export class MapLikelyRsLayer {
    */
   async fetchLikelyRsGeoJson(coords) {
     const url = `${cartoAPIv3BaseURL}/v3/sql/carto_dw/query`;
-    const headers = new Headers();
-    headers.append("Authorization", `Bearer ${cartoApiKey}`);
+    const requestOptions = cartoSqlApiAuthOptions();
 
-    const requestOptions = {
-      method: "GET",
-      headers: headers,
-      redirect: "follow",
-    };
     const res = await fetch(
       `${url}?q=${encodeURIComponent(
         rentStabilizedGeomSql({ lon: coords[0], lat: coords[1] })
       )}`,
       requestOptions
     );
+
     if (res.ok) {
       this._likelyRsGeoJson = await res.json();
     } else {

--- a/app/src/components/mapLikelyRsLayer.js
+++ b/app/src/components/mapLikelyRsLayer.js
@@ -39,7 +39,7 @@ export class MapLikelyRsLayer {
     this.init();
   }
 
-  async init() {
+  init() {
     this._pathGenerator = geoPath(this.projection);
   }
 
@@ -47,7 +47,7 @@ export class MapLikelyRsLayer {
    * handles rendering the SVG map's likely RS polygon map layer
    * @returns {Promise<string | undefined>}
    */
-  async render(rsGeoJson) {
+  render(rsGeoJson) {
     if (Array.isArray(rsGeoJson) && rsGeoJson.length) {
       const paths = this.getRsPolygonPaths(rsGeoJson);
       return paths;

--- a/app/src/components/mapLikelyRsLayer.js
+++ b/app/src/components/mapLikelyRsLayer.js
@@ -13,6 +13,18 @@ const LAYER_STYLES = {
 };
 
 /**
+ * @typedef {object} Row
+ * @property {string} geojson
+ */
+
+/**
+ * @typedef {object} Feature
+ * @property {string} type
+ * @property {object} properties
+ * @property {object} geometry
+ */
+
+/**
  * class that handles rendering the SearchResultMap's likely rent-stabilized data layer of SVG path elements
  * - queries the Carto SQL API for a GeoJSON representation of likely RS properties
  * - transforms GeoJSON to SVG path elements suitable for rendering in the appropriate map layer
@@ -23,7 +35,7 @@ export class MapLikelyRsLayer {
     this.dimensions = searchResultMap.dimensions;
     this.projection = searchResultMap.projection;
 
-    /** @type {null | Object} Carto SQL API result of GeoJSON geometries of likely RS properties */
+    /** @type {null | Row[]} Carto SQL API result of GeoJSON geometries of likely RS properties */
     this._likelyRsGeoJson = null;
 
     /** @type {null | ReturnType<geoPath>} d3-geo SVG path generator */
@@ -65,7 +77,7 @@ export class MapLikelyRsLayer {
 
   /**
    * converts GeoJSON features to string representation of SVG path elements
-   * @param {any[]} features - array of GeoJSON features
+   * @param {Feature[]} features - array of GeoJSON features
    * @returns {string}
    */
   renderGeoJsonPaths(features) {
@@ -85,8 +97,8 @@ export class MapLikelyRsLayer {
 
   /**
    * converts Carto SQL API geometries to an array of correctly formatted GeoJSON features
-   * @param {any[]} rows - query rows result
-   * @returns {any[]}
+   * @param {Row[]} rows - query rows result
+   * @returns {Feature[]}
    */
   processQueryResult(rows) {
     const features = rows.map((d) =>

--- a/app/src/components/mapTileLayers.js
+++ b/app/src/components/mapTileLayers.js
@@ -1,10 +1,6 @@
 import * as d3Tile from "d3-tile";
-import { mapsApiSql, rentStabilizedGeomSql } from "../utils/sql";
-import {
-  cartoAccount,
-  cartoAPIv3BaseURL,
-  cartoApiKey,
-} from "../constants/config";
+import { mapsApiSql } from "../utils/sql";
+import { cartoAccount } from "../constants/config";
 import { logException, handleErrorObj } from "../utils/logging";
 
 export class MapTileLayers {
@@ -13,14 +9,12 @@ export class MapTileLayers {
     this.dimensions = searchResultMap.dimensions;
     this.projection = searchResultMap.projection;
     this._cartoTilesSchema = null;
-    this._likelyRsGeoJson = null;
 
     this.renderMapTile = this.renderMapTile.bind(this);
     this.renderMapTiles = this.renderMapTiles.bind(this);
     this.getBasemapTileUrl = this.getBasemapTileUrl.bind(this);
     this.getDataTileUrl = this.getDataTileUrl.bind(this);
     this.fetchCartoTilesSchema = this.fetchCartoTilesSchema.bind(this);
-    this.fetchLikelyRsGeoJson = this.fetchLikelyRsGeoJson.bind(this);
     this.init = this.init.bind(this);
 
     this.init();
@@ -29,11 +23,6 @@ export class MapTileLayers {
   async init() {
     try {
       await this.fetchCartoTilesSchema();
-
-      // TODO: delete these two lines, only a test
-      await this.fetchLikelyRsGeoJson([-73.95757, 40.658]);
-      console.log(this._likelyRsGeoJson);
-
       if (this.cartoTilesSchema) {
         this.searchResultMap.updateProjection();
         this.searchResultMap.renderMap();
@@ -41,29 +30,6 @@ export class MapTileLayers {
     } catch (error) {
       logException(handleErrorObj("MapTileLayers.init", error), true);
     }
-  }
-
-  /**
-   *
-   * @param {[number, number]} coords [lon, lat]
-   */
-  async fetchLikelyRsGeoJson(coords) {
-    const url = `${cartoAPIv3BaseURL}/v3/sql/carto_dw/query`;
-    const headers = new Headers();
-    headers.append("Authorization", `Bearer ${cartoApiKey}`);
-
-    const requestOptions = {
-      method: "GET",
-      headers: headers,
-      redirect: "follow",
-    };
-    const res = await fetch(
-      `${url}?q=${encodeURIComponent(
-        rentStabilizedGeomSql({ lon: coords[0], lat: coords[1] })
-      )}`,
-      requestOptions
-    );
-    this._likelyRsGeoJson = await res.json();
   }
 
   async fetchCartoTilesSchema() {

--- a/app/src/components/mapTileLayers.js
+++ b/app/src/components/mapTileLayers.js
@@ -1,6 +1,4 @@
 import * as d3Tile from "d3-tile";
-import { mapsApiSql } from "../utils/sql";
-import { cartoAccount } from "../constants/config";
 import { logException, handleErrorObj } from "../utils/logging";
 
 export class MapTileLayers {
@@ -8,13 +6,10 @@ export class MapTileLayers {
     this.searchResultMap = searchResultMap;
     this.dimensions = searchResultMap.dimensions;
     this.projection = searchResultMap.projection;
-    this._cartoTilesSchema = null;
 
     this.renderMapTile = this.renderMapTile.bind(this);
     this.renderMapTiles = this.renderMapTiles.bind(this);
     this.getBasemapTileUrl = this.getBasemapTileUrl.bind(this);
-    this.getDataTileUrl = this.getDataTileUrl.bind(this);
-    this.fetchCartoTilesSchema = this.fetchCartoTilesSchema.bind(this);
     this.init = this.init.bind(this);
 
     this.init();
@@ -22,64 +17,38 @@ export class MapTileLayers {
 
   async init() {
     try {
-      await this.fetchCartoTilesSchema();
-      if (this.cartoTilesSchema) {
-        this.searchResultMap.updateProjection();
-        this.searchResultMap.renderMap();
-      }
+      this.searchResultMap.updateProjection();
+      await this.searchResultMap.renderMap();
     } catch (error) {
       logException(handleErrorObj("MapTileLayers.init", error), true);
     }
   }
 
-  async fetchCartoTilesSchema() {
-    const mapsApiUrl = `https://${cartoAccount}.carto.com/api/v1/map/`;
-    const res = await fetch(
-      `${mapsApiUrl}?config=${encodeURIComponent(
-        JSON.stringify(this.mapsApiConfig)
-      )}`
-    );
-    const json = await res.json();
-    this._cartoTilesSchema = json;
-  }
-
-  renderMapTiles(type) {
+  renderMapTiles() {
     return this.tiles
-      .map((path, i, transform) => this.renderMapTile(path, transform, type))
+      .map((path, i, transform) => this.renderMapTile(path, transform))
       .join("");
   }
 
-  renderMapTile(path, transform, type) {
+  renderMapTile(path, transform) {
     const [x, y, z] = path;
     const {
       translate: [tx, ty],
       scale: k,
     } = transform;
-    const getTileUrl =
-      type === "basemap" ? this.getBasemapTileUrl : this.getDataTileUrl;
-    return `<image xlink:href="${getTileUrl(x, y, z)}" x="${Math.round(
-      (x + tx) * k
-    )}" y="${Math.round((y + ty) * k)}" width="${k}" height="${k}"></image>`;
+    return `<image xlink:href="${this.getBasemapTileUrl(
+      x,
+      y,
+      z
+    )}" x="${Math.round((x + tx) * k)}" y="${Math.round(
+      (y + ty) * k
+    )}" width="${k}" height="${k}"></image>`;
   }
 
   getBasemapTileUrl(x, y, z) {
     return `https://cartodb-basemaps-${
       "abc"[Math.abs(x + y) % 3]
     }.global.ssl.fastly.net/light_all/${z}/${x}/${y}${
-      devicePixelRatio > 1 ? "@2x" : ""
-    }.png`;
-  }
-
-  getDataTileUrl(x, y, z) {
-    const { layergroupid, cdn_url } = this.cartoTilesSchema;
-    const {
-      templates: { https },
-    } = cdn_url;
-    const baseURL = https.url.replace(
-      "{s}",
-      https.subdomains[Math.abs(x + y) % https.subdomains.length]
-    );
-    return `${baseURL}/${cartoAccount}/api/v1/map/${layergroupid}/${z}/${x}/${y}${
       devicePixelRatio > 1 ? "@2x" : ""
     }.png`;
   }
@@ -95,42 +64,5 @@ export class MapTileLayers {
 
   get tiles() {
     return this.tileSchema();
-  }
-
-  get cartoTilesSchema() {
-    return this._cartoTilesSchema;
-  }
-
-  set cartoTilesSchema(schema) {
-    if (schema && schema.cdn_url && schema.layergroupid) {
-      this._cartoTilesSchema = schema;
-    } else {
-      throw "Invalid CARTO tiles schema";
-    }
-  }
-
-  get cartocss() {
-    return `#layer {
-      polygon-fill: #FF6600;
-      polygon-opacity: 0.6;
-      line-width: 0.7;
-      line-color: #FFF;
-      line-opacity: 0.3;
-    }`;
-  }
-
-  get mapsApiConfig() {
-    return {
-      layers: [
-        {
-          type: "cartodb",
-          options: {
-            sql: mapsApiSql(),
-            cartocss: this.cartocss,
-            cartocss_version: "2.1.0",
-          },
-        },
-      ],
-    };
   }
 }

--- a/app/src/components/mapTileLayers.js
+++ b/app/src/components/mapTileLayers.js
@@ -1,27 +1,13 @@
 import * as d3Tile from "d3-tile";
-import { logException, handleErrorObj } from "../utils/logging";
 
 export class MapTileLayers {
   constructor(searchResultMap) {
     this.searchResultMap = searchResultMap;
     this.dimensions = searchResultMap.dimensions;
     this.projection = searchResultMap.projection;
-
     this.renderMapTile = this.renderMapTile.bind(this);
     this.renderMapTiles = this.renderMapTiles.bind(this);
     this.getBasemapTileUrl = this.getBasemapTileUrl.bind(this);
-    this.init = this.init.bind(this);
-
-    this.init();
-  }
-
-  async init() {
-    try {
-      this.searchResultMap.updateProjection();
-      await this.searchResultMap.renderMap();
-    } catch (error) {
-      logException(handleErrorObj("MapTileLayers.init", error), true);
-    }
   }
 
   renderMapTiles() {

--- a/app/src/components/mapTileLayers.spec.js
+++ b/app/src/components/mapTileLayers.spec.js
@@ -1,7 +1,7 @@
 import { store } from "../store";
 import { MapTileLayers } from "./mapTileLayers";
 import { SearchResultMap } from "./searchResultMap";
-import { logException, handleErrorObj } from "../utils/logging";
+import { handleErrorObj } from "../utils/logging";
 const d3Tile = require("d3-tile");
 
 jest.mock("../store");
@@ -101,20 +101,6 @@ describe("MapTileLayers", () => {
 
   test("The consumer should be able to call new() on MapTileLayers", () => {
     expect(mapTileLayers).toBeTruthy();
-  });
-
-  test("init", async () => {
-    const spy1 = jest.spyOn(SearchResultMap.prototype, "updateProjection");
-    const spy2 = jest.spyOn(SearchResultMap.prototype, "renderMap");
-    const mapTileLayers = new MapTileLayers(
-      new SearchResultMap({
-        element,
-        store,
-      })
-    );
-    await mapTileLayers.init();
-    expect(spy1).toHaveBeenCalled();
-    expect(spy2).toHaveBeenCalled();
   });
 
   test("renderMapTiles", () => {

--- a/app/src/components/mapTileLayers.spec.js
+++ b/app/src/components/mapTileLayers.spec.js
@@ -104,9 +104,8 @@ describe("MapTileLayers", () => {
   });
 
   test("init", async () => {
-    const spy1 = jest.spyOn(MapTileLayers.prototype, "fetchCartoTilesSchema");
-    const spy2 = jest.spyOn(SearchResultMap.prototype, "updateProjection");
-    const spy3 = jest.spyOn(SearchResultMap.prototype, "renderMap");
+    const spy1 = jest.spyOn(SearchResultMap.prototype, "updateProjection");
+    const spy2 = jest.spyOn(SearchResultMap.prototype, "renderMap");
     const mapTileLayers = new MapTileLayers(
       new SearchResultMap({
         element,
@@ -116,42 +115,30 @@ describe("MapTileLayers", () => {
     await mapTileLayers.init();
     expect(spy1).toHaveBeenCalled();
     expect(spy2).toHaveBeenCalled();
-    expect(spy3).toHaveBeenCalled();
-  });
-
-  test("init handles error", async () => {
-    fetch.mockReject(new Error("Problems"));
-    const mapTileLayers = new MapTileLayers(
-      new SearchResultMap({
-        element,
-        store,
-      })
-    );
-    await mapTileLayers.init();
-    expect(logException).toHaveBeenCalledWith(
-      "MapTileLayers.init; Error; Problems",
-      true
-    );
-  });
-
-  test("fetchCartoTilesSchema", async () => {
-    await mapTileLayers.fetchCartoTilesSchema();
-    expect(mapTileLayers.cartoTilesSchema).toBeTruthy();
   });
 
   test("renderMapTiles", () => {
     const result = mapTileLayers.renderMapTiles();
-    const expected =
-      '<image xlink:href="https://cartocdn-gusc-d.global.ssl.fastly.net/chenrick/api/v1/map/blablabla/12/1204/1539.png" x="-234" y="-126" width="256" height="256"></image><image xlink:href="https://cartocdn-gusc-a.global.ssl.fastly.net/chenrick/api/v1/map/blablabla/12/1205/1539.png" x="22" y="-126" width="256" height="256"></image><image xlink:href="https://cartocdn-gusc-b.global.ssl.fastly.net/chenrick/api/v1/map/blablabla/12/1206/1539.png" x="278" y="-126" width="256" height="256"></image><image xlink:href="https://cartocdn-gusc-c.global.ssl.fastly.net/chenrick/api/v1/map/blablabla/12/1207/1539.png" x="534" y="-126" width="256" height="256"></image><image xlink:href="https://cartocdn-gusc-a.global.ssl.fastly.net/chenrick/api/v1/map/blablabla/12/1204/1540.png" x="-234" y="130" width="256" height="256"></image><image xlink:href="https://cartocdn-gusc-b.global.ssl.fastly.net/chenrick/api/v1/map/blablabla/12/1205/1540.png" x="22" y="130" width="256" height="256"></image><image xlink:href="https://cartocdn-gusc-c.global.ssl.fastly.net/chenrick/api/v1/map/blablabla/12/1206/1540.png" x="278" y="130" width="256" height="256"></image><image xlink:href="https://cartocdn-gusc-d.global.ssl.fastly.net/chenrick/api/v1/map/blablabla/12/1207/1540.png" x="534" y="130" width="256" height="256"></image>';
+    const expected = `<image xlink:href="https://cartodb-basemaps-b.global.ssl.fastly.net/light_all/12/1204/1539.png" x="-234" y="-126" width="256" height="256"></image>
+        <image xlink:href="https://cartodb-basemaps-c.global.ssl.fastly.net/light_all/12/1205/1539.png" x="22" y="-126" width="256" height="256"></image>
+        <image xlink:href="https://cartodb-basemaps-a.global.ssl.fastly.net/light_all/12/1206/1539.png" x="278" y="-126" width="256" height="256"></image>
+        <image xlink:href="https://cartodb-basemaps-b.global.ssl.fastly.net/light_all/12/1207/1539.png" x="534" y="-126" width="256" height="256"></image>
+        <image xlink:href="https://cartodb-basemaps-c.global.ssl.fastly.net/light_all/12/1204/1540.png" x="-234" y="130" width="256" height="256"></image>
+        <image xlink:href="https://cartodb-basemaps-a.global.ssl.fastly.net/light_all/12/1205/1540.png" x="22" y="130" width="256" height="256"></image>
+        <image xlink:href="https://cartodb-basemaps-b.global.ssl.fastly.net/light_all/12/1206/1540.png" x="278" y="130" width="256" height="256"></image>
+        <image xlink:href="https://cartodb-basemaps-c.global.ssl.fastly.net/light_all/12/1207/1540.png" x="534" y="130" width="256" height="256"></image>
+      `
+      .split("\n")
+      .map((d) => d.trim())
+      .join("");
     expect(result).toEqual(expected);
   });
 
   test("renderMapTile", () => {
-    const result = mapTileLayers.renderMapTile(
-      [19295, 24633, 16],
-      { translate: [-19295.691937688887, -24633.71588863962], scale: 256 },
-      "basemap"
-    );
+    const result = mapTileLayers.renderMapTile([19295, 24633, 16], {
+      translate: [-19295.691937688887, -24633.71588863962],
+      scale: 256,
+    });
     const expected =
       "<image xlink:href=" +
       '"https://cartodb-basemaps-c.global.ssl.fastly.net/light_all/16/19295/24633.png" ' +
@@ -168,36 +155,6 @@ describe("MapTileLayers", () => {
     window.devicePixelRatio = 1;
     expect(mapTileLayers.getBasemapTileUrl(1, 2, 3)).toEqual(
       "https://cartodb-basemaps-a.global.ssl.fastly.net/light_all/3/1/2.png"
-    );
-  });
-
-  test("getDataTileUrl", () => {
-    window.devicePixelRatio = 2;
-    mapTileLayers.cartoTilesSchema = {
-      layergroupid: "blablabla",
-      cdn_url: {
-        templates: {
-          https: {
-            url: "https://cartocdn-gusc-{s}.global.ssl.fastly.net",
-            subdomains: ["a", "b", "c", "d"],
-          },
-        },
-      },
-    };
-
-    expect(mapTileLayers.getDataTileUrl(40, 30, 20)).toEqual(
-      "https://cartocdn-gusc-c.global.ssl.fastly.net/chenrick/api/v1/map/blablabla/20/40/30@2x.png"
-    );
-
-    window.devicePixelRatio = 1;
-    expect(mapTileLayers.getDataTileUrl(1, 2, 3)).toEqual(
-      "https://cartocdn-gusc-d.global.ssl.fastly.net/chenrick/api/v1/map/blablabla/3/1/2.png"
-    );
-  });
-
-  test("cartoTilesSchema should throw when not set correctly", () => {
-    expect(() => (mapTileLayers.cartoTilesSchema = {})).toThrow(
-      "Invalid CARTO tiles schema"
     );
   });
 });

--- a/app/src/components/searchResultMap.js
+++ b/app/src/components/searchResultMap.js
@@ -4,7 +4,6 @@ import { MapTileLayers } from "./mapTileLayers";
 import { MapPopup } from "./mapPopup";
 import { MapLikelyRsLayer } from "./mapLikelyRsLayer";
 import { observeStore } from "../store";
-import { fetchRentStabilizedGeoJSON } from "../action_creators/rentStabilizedGeoJsonActions";
 import {
   MAP_ZOOM,
   MAP_CENTER,
@@ -45,14 +44,13 @@ export class SearchResultMap extends Component {
     this.renderMap = this.renderMap.bind(this);
     this.resetMap = this.resetMap.bind(this);
 
-    this.unsubscribe = observeStore(
+    this.unsubscribeSearchResult = observeStore(
       this.store,
       (state) => state.addressGeocode.searchResult,
       this.handleSearchResult
     );
 
-    // FIXME: need to update `observeStore` to subscribe to multiple slices of state?
-    this.unsubscribe2 = observeStore(
+    this.unsubscribeRsGeoJson = observeStore(
       this.store,
       (state) => state.rentStabilizedGeoJson.geojson,
       this.handleRentStabilizedGeoJson
@@ -60,8 +58,8 @@ export class SearchResultMap extends Component {
   }
 
   cleanUp() {
-    this.unsubscribe();
-    this.unsubscribe2();
+    this.unsubscribeSearchResult();
+    this.unsubscribeRsGeoJson();
   }
 
   handleRentStabilizedGeoJson() {
@@ -74,21 +72,9 @@ export class SearchResultMap extends Component {
   handleSearchResult() {
     const hasSearchResult = this.searchResult?.features?.length;
     if (hasSearchResult) {
-      this.fetchRentStabilizedGeoJson();
       this.updateMapView();
     } else {
       this.resetMap();
-    }
-  }
-
-  fetchRentStabilizedGeoJson() {
-    const feature = this.searchResult.features[0];
-    if (
-      Array.isArray(feature?.geometry?.coordinates) &&
-      feature.geometry.coordinates.length
-    ) {
-      const [lon, lat] = feature.geometry.coordinates;
-      this.store.dispatch(fetchRentStabilizedGeoJSON({ lon, lat }));
     }
   }
 

--- a/app/src/components/searchResultMap.js
+++ b/app/src/components/searchResultMap.js
@@ -47,14 +47,27 @@ export class SearchResultMap extends Component {
       (state) => state.addressGeocode.searchResult,
       this.handleSearchResult
     );
+
+    // FIXME: need to update `observeStore` to subscribe to multiple slices of state?
+    // TODO: handle calling `this.unsubscribe2()` in cleanup fn?
+    this.unsubscribe2 = observeStore(
+      this.store,
+      (state) => state.rentStabilizedGeoJson.geojson,
+      this.handleRentStabilizedGeoJson
+    );
+  }
+
+  async handleRentStabilizedGeoJson(geojson) {
+    if (Array.isArray(geojson?.rows) && geojson?.rows.length) {
+      // TODO: handle converting row objects into GeoJSON features with correct polygon coordinate winding order
+      console.log("handleRentStabilizedGeoJson: ", geojson.rows);
+    }
   }
 
   async handleSearchResult() {
-    if (
-      this.searchResult &&
-      this.searchResult.features &&
-      this.searchResult.features.length
-    ) {
+    const hasSearchResult = this.searchResult?.features?.length;
+
+    if (hasSearchResult) {
       await this.fetchRentStabilizedGeoJson();
       await this.updateMapView();
     }

--- a/app/src/components/searchResultMap.js
+++ b/app/src/components/searchResultMap.js
@@ -83,7 +83,10 @@ export class SearchResultMap extends Component {
     this.setMapSize();
     this.gBaseTiles.innerHTML = this.mapTileLayers.renderMapTiles("basemap");
     // this.gRsTiles.innerHTML = this.mapTileLayers.renderMapTiles("data");
-    this.gRsTiles.innerHTML = await this.mapLikelyRsLayer.renderMapLikelyRsLayer();
+    const likelyRsLayer = await this.mapLikelyRsLayer.renderMapLikelyRsLayer();
+    if (likelyRsLayer) {
+      this.gRsTiles.innerHTML = likelyRsLayer;
+    }
   }
 
   setMapSize() {

--- a/app/src/components/searchResultMap.js
+++ b/app/src/components/searchResultMap.js
@@ -48,7 +48,7 @@ export class SearchResultMap extends Component {
     );
   }
 
-  handleSearchResult() {
+  async handleSearchResult() {
     if (
       this.searchResult &&
       this.searchResult.features &&
@@ -58,7 +58,7 @@ export class SearchResultMap extends Component {
     }
   }
 
-  updateMapView() {
+  async updateMapView() {
     if (!this.searchResultDetails || !this.searchResultDetails.coordinates) {
       return;
     }
@@ -71,7 +71,7 @@ export class SearchResultMap extends Component {
     } = this.searchResultDetails;
     this.zoom = MAP_ZOOM.RESULT;
     this.center = coordinates;
-    this.renderMap();
+    await this.renderMap();
     this.showMarker();
     this.setMarkerPosition();
     this.popup.show();
@@ -79,10 +79,11 @@ export class SearchResultMap extends Component {
     this.popup.setPosition();
   }
 
-  renderMap() {
+  async renderMap() {
     this.setMapSize();
     this.gBaseTiles.innerHTML = this.mapTileLayers.renderMapTiles("basemap");
-    this.gRsTiles.innerHTML = this.mapTileLayers.renderMapTiles("data");
+    // this.gRsTiles.innerHTML = this.mapTileLayers.renderMapTiles("data");
+    this.gRsTiles.innerHTML = await this.mapLikelyRsLayer.renderMapLikelyRsLayer();
   }
 
   setMapSize() {

--- a/app/src/components/searchResultMap.js
+++ b/app/src/components/searchResultMap.js
@@ -64,25 +64,24 @@ export class SearchResultMap extends Component {
     this.unsubscribe2();
   }
 
-  async handleRentStabilizedGeoJson() {
+  handleRentStabilizedGeoJson() {
     const hasRsGeoJson = Array.isArray(this.rsGeoJson) && this.rsGeoJson.length;
     if (hasRsGeoJson) {
-      await this.renderMap();
+      this.renderMap();
     }
   }
 
-  async handleSearchResult() {
+  handleSearchResult() {
     const hasSearchResult = this.searchResult?.features?.length;
-
     if (hasSearchResult) {
-      await this.fetchRentStabilizedGeoJson();
-      await this.updateMapView();
+      this.fetchRentStabilizedGeoJson();
+      this.updateMapView();
     } else {
-      await this.resetMap();
+      this.resetMap();
     }
   }
 
-  async fetchRentStabilizedGeoJson() {
+  fetchRentStabilizedGeoJson() {
     const feature = this.searchResult.features[0];
     if (
       Array.isArray(feature?.geometry?.coordinates) &&
@@ -93,7 +92,7 @@ export class SearchResultMap extends Component {
     }
   }
 
-  async updateMapView() {
+  updateMapView() {
     if (!this.searchResultDetails || !this.searchResultDetails.coordinates) {
       return;
     }
@@ -106,7 +105,7 @@ export class SearchResultMap extends Component {
     } = this.searchResultDetails;
     this.zoom = MAP_ZOOM.RESULT;
     this.center = coordinates;
-    await this.renderMap();
+    this.renderMap();
     this.showMarker();
     this.setMarkerPosition();
     this.popup.show();
@@ -114,14 +113,11 @@ export class SearchResultMap extends Component {
     this.popup.setPosition();
   }
 
-  /**
-   * @returns {Promise}
-   */
-  async renderMap() {
+  renderMap() {
     this.setMapSize();
     this.gBaseTiles.innerHTML = this.mapTileLayers.renderMapTiles();
     if (this.rsGeoJson) {
-      const likelyRsLayer = await this.mapLikelyRsLayer.render(this.rsGeoJson);
+      const likelyRsLayer = this.mapLikelyRsLayer.render(this.rsGeoJson);
       this.gRsTiles.innerHTML = likelyRsLayer;
     } else {
       this.gRsTiles.innerHTML = "";
@@ -159,12 +155,12 @@ export class SearchResultMap extends Component {
     this.marker.setAttribute("opacity", 0);
   }
 
-  async resetMap() {
+  resetMap() {
     this.zoom = MAP_ZOOM.DEFAULT;
     this.center = MAP_CENTER.DEFAULT;
     this.hideMarker();
     this.popup.hide();
-    await this.renderMap();
+    this.renderMap();
   }
 
   get dimensions() {

--- a/app/src/components/searchResultMap.js
+++ b/app/src/components/searchResultMap.js
@@ -77,6 +77,8 @@ export class SearchResultMap extends Component {
     if (hasSearchResult) {
       await this.fetchRentStabilizedGeoJson();
       await this.updateMapView();
+    } else {
+      await this.resetMap();
     }
   }
 
@@ -121,6 +123,8 @@ export class SearchResultMap extends Component {
     if (this.rsGeoJson) {
       const likelyRsLayer = await this.mapLikelyRsLayer.render(this.rsGeoJson);
       this.gRsTiles.innerHTML = likelyRsLayer;
+    } else {
+      this.gRsTiles.innerHTML = "";
     }
   }
 

--- a/app/src/components/searchResultMap.js
+++ b/app/src/components/searchResultMap.js
@@ -4,6 +4,7 @@ import { MapTileLayers } from "./mapTileLayers";
 import { MapPopup } from "./mapPopup";
 import { MapLikelyRsLayer } from "./mapLikelyRsLayer";
 import { observeStore } from "../store";
+import { fetchRentStabilizedGeoJSON } from "../action_creators/rentStabilizedGeoJsonActions";
 import {
   MAP_ZOOM,
   MAP_CENTER,
@@ -54,7 +55,19 @@ export class SearchResultMap extends Component {
       this.searchResult.features &&
       this.searchResult.features.length
     ) {
-      this.updateMapView();
+      await this.fetchRentStabilizedGeoJson();
+      await this.updateMapView();
+    }
+  }
+
+  async fetchRentStabilizedGeoJson() {
+    const feature = this.searchResult.features[0];
+    if (
+      Array.isArray(feature?.geometry?.coordinates) &&
+      feature.geometry.coordinates.length
+    ) {
+      const [lon, lat] = feature.geometry.coordinates;
+      this.store.dispatch(fetchRentStabilizedGeoJSON({ lon, lat }));
     }
   }
 

--- a/app/src/components/searchResultMap.js
+++ b/app/src/components/searchResultMap.js
@@ -2,6 +2,7 @@ import { geoMercator } from "d3-geo";
 import { Component } from "./_componentBase";
 import { MapTileLayers } from "./mapTileLayers";
 import { MapPopup } from "./mapPopup";
+import { MapLikelyRsLayer } from "./mapLikelyRsLayer";
 import { observeStore } from "../store";
 import {
   MAP_ZOOM,
@@ -32,6 +33,7 @@ export class SearchResultMap extends Component {
     this._projection = geoMercator();
 
     this.mapTileLayers = new MapTileLayers(this);
+    this.mapLikelyRsLayer = new MapLikelyRsLayer(this);
 
     this.updateProjection = this.updateProjection.bind(this);
     this.updateMapView = this.updateMapView.bind(this);

--- a/app/src/components/searchResultMap.js
+++ b/app/src/components/searchResultMap.js
@@ -21,7 +21,7 @@ export class SearchResultMap extends Component {
 
     this.svg = this.element.querySelector("svg");
     this.gBaseTiles = this.svg.querySelector("g.tiles-base-map");
-    this.gRsTiles = this.svg.querySelector("g.tiles-rent-stabilized");
+    this.gRsLayer = this.svg.querySelector("g.layer-rent-stabilized");
     this.marker = this.svg.querySelector("g.location-marker");
     this.popup = new MapPopup({
       element: this.element.querySelector("div.map-pop-up"),
@@ -104,9 +104,9 @@ export class SearchResultMap extends Component {
     this.gBaseTiles.innerHTML = this.mapTileLayers.renderMapTiles();
     if (this.rsGeoJson) {
       const likelyRsLayer = this.mapLikelyRsLayer.render(this.rsGeoJson);
-      this.gRsTiles.innerHTML = likelyRsLayer;
+      this.gRsLayer.innerHTML = likelyRsLayer;
     } else {
-      this.gRsTiles.innerHTML = "";
+      this.gRsLayer.innerHTML = "";
     }
   }
 

--- a/app/src/components/searchResultMap.js
+++ b/app/src/components/searchResultMap.js
@@ -67,7 +67,7 @@ export class SearchResultMap extends Component {
   async handleRentStabilizedGeoJson() {
     const hasRsGeoJson = Array.isArray(this.rsGeoJson) && this.rsGeoJson.length;
     if (hasRsGeoJson) {
-      this.renderMap();
+      await this.renderMap();
     }
   }
 
@@ -112,6 +112,9 @@ export class SearchResultMap extends Component {
     this.popup.setPosition();
   }
 
+  /**
+   * @returns {Promise}
+   */
   async renderMap() {
     this.setMapSize();
     this.gBaseTiles.innerHTML = this.mapTileLayers.renderMapTiles();
@@ -152,12 +155,12 @@ export class SearchResultMap extends Component {
     this.marker.setAttribute("opacity", 0);
   }
 
-  resetMap() {
+  async resetMap() {
     this.zoom = MAP_ZOOM.DEFAULT;
     this.center = MAP_CENTER.DEFAULT;
     this.hideMarker();
     this.popup.hide();
-    this.renderMap();
+    await this.renderMap();
   }
 
   get dimensions() {

--- a/app/src/components/searchResultMap.js
+++ b/app/src/components/searchResultMap.js
@@ -81,8 +81,7 @@ export class SearchResultMap extends Component {
 
   async renderMap() {
     this.setMapSize();
-    this.gBaseTiles.innerHTML = this.mapTileLayers.renderMapTiles("basemap");
-    // this.gRsTiles.innerHTML = this.mapTileLayers.renderMapTiles("data");
+    this.gBaseTiles.innerHTML = this.mapTileLayers.renderMapTiles();
     const likelyRsLayer = await this.mapLikelyRsLayer.renderMapLikelyRsLayer();
     if (likelyRsLayer) {
       this.gRsTiles.innerHTML = likelyRsLayer;

--- a/app/src/components/searchResultMap.spec.js
+++ b/app/src/components/searchResultMap.spec.js
@@ -234,7 +234,7 @@ describe("SearchResultMap", () => {
     });
     expect(spy2).toHaveBeenCalledTimes(1);
     expect(spy3).toHaveBeenCalledTimes(1);
-    expect(spy4).toHaveBeenCalledTimes(1);
+    expect(spy4).toHaveBeenCalledTimes(2);
     expect(spy5).toHaveBeenCalledTimes(1);
     expect(spy6).toHaveBeenCalledTimes(1);
   });
@@ -250,7 +250,7 @@ describe("SearchResultMap", () => {
     expect(spy1).not.toHaveBeenCalled();
     expect(spy2).not.toHaveBeenCalled();
     expect(spy3).not.toHaveBeenCalled();
-    expect(spy4).not.toHaveBeenCalled();
+    expect(spy4).toHaveBeenCalledTimes(2);
     expect(spy5).not.toHaveBeenCalled();
     expect(spy6).not.toHaveBeenCalled();
   });
@@ -261,7 +261,7 @@ describe("SearchResultMap", () => {
     const spy = jest.spyOn(SearchResultMap.prototype, "setMapSize");
     const instance = new SearchResultMap({ element, store });
     await instance.renderMap();
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledTimes(2);
     expect(instance.gBaseTiles.childNodes).toBeDefined();
     expect(instance.gRsTiles.childNodes).toBeDefined();
   });
@@ -314,9 +314,9 @@ describe("SearchResultMap", () => {
     const spy3 = jest.spyOn(MapPopup.prototype, "hide");
     const instance = new SearchResultMap({ store, element });
     await instance.resetMap();
-    expect(spy1).toHaveBeenCalledTimes(1);
-    expect(spy2).toHaveBeenCalledTimes(1);
-    expect(spy3).toHaveBeenCalledTimes(1);
+    expect(spy1).toHaveBeenCalledTimes(2);
+    expect(spy2).toHaveBeenCalledTimes(3);
+    expect(spy3).toHaveBeenCalledTimes(2);
     expect(instance.zoom).toEqual(MAP_ZOOM.DEFAULT);
     expect(instance.center).toEqual(MAP_CENTER.DEFAULT);
   });

--- a/app/src/components/searchResultMap.spec.js
+++ b/app/src/components/searchResultMap.spec.js
@@ -135,7 +135,7 @@ describe("SearchResultMap", () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
-  test("handleSearchResult", async () => {
+  test("handleSearchResult", () => {
     const spy = jest.spyOn(SearchResultMap.prototype, "updateMapView");
     const instance = new SearchResultMap({ element, store });
     store.getState.mockImplementation(() => ({
@@ -171,7 +171,7 @@ describe("SearchResultMap", () => {
         geojson: null,
       },
     }));
-    await instance.handleSearchResult();
+    instance.handleSearchResult();
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
@@ -182,7 +182,7 @@ describe("SearchResultMap", () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  test("updateMapView", async () => {
+  test("updateMapView", () => {
     const spy1 = jest.spyOn(MapPopup.prototype, "setContent");
     const spy2 = jest.spyOn(MapPopup.prototype, "show");
     const spy6 = jest.spyOn(MapPopup.prototype, "setPosition");
@@ -223,7 +223,7 @@ describe("SearchResultMap", () => {
         geojson: null,
       },
     }));
-    await instance.updateMapView();
+    instance.updateMapView();
     expect(instance.zoom).toEqual(MAP_ZOOM.RESULT);
     expect(instance.center).toEqual([0, 0]);
     expect(spy1).toHaveBeenCalledWith({
@@ -255,12 +255,12 @@ describe("SearchResultMap", () => {
     expect(spy6).not.toHaveBeenCalled();
   });
 
-  test("renderMap", async () => {
+  test("renderMap", () => {
     MapTileLayers.mockRestore();
     const { SearchResultMap } = require("./searchResultMap");
     const spy = jest.spyOn(SearchResultMap.prototype, "setMapSize");
     const instance = new SearchResultMap({ element, store });
-    await instance.renderMap();
+    instance.renderMap();
     expect(spy).toHaveBeenCalledTimes(2);
     expect(instance.gBaseTiles.childNodes).toBeDefined();
     expect(instance.gRsTiles.childNodes).toBeDefined();
@@ -308,12 +308,12 @@ describe("SearchResultMap", () => {
     expect(searchResultMap.marker.getAttribute("opacity")).toBe("0");
   });
 
-  test("resetMap", async () => {
+  test("resetMap", () => {
     const spy1 = jest.spyOn(SearchResultMap.prototype, "hideMarker");
     const spy2 = jest.spyOn(SearchResultMap.prototype, "renderMap");
     const spy3 = jest.spyOn(MapPopup.prototype, "hide");
     const instance = new SearchResultMap({ store, element });
-    await instance.resetMap();
+    instance.resetMap();
     expect(spy1).toHaveBeenCalledTimes(2);
     expect(spy2).toHaveBeenCalledTimes(3);
     expect(spy3).toHaveBeenCalledTimes(2);

--- a/app/src/components/searchResultMap.spec.js
+++ b/app/src/components/searchResultMap.spec.js
@@ -172,7 +172,7 @@ describe("SearchResultMap", () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  test("updateMapView", () => {
+  test("updateMapView", async () => {
     const spy1 = jest.spyOn(MapPopup.prototype, "setContent");
     const spy2 = jest.spyOn(MapPopup.prototype, "show");
     const spy6 = jest.spyOn(MapPopup.prototype, "setPosition");
@@ -208,7 +208,7 @@ describe("SearchResultMap", () => {
         match: null,
       },
     }));
-    instance.updateMapView();
+    await instance.updateMapView();
     expect(instance.zoom).toEqual(MAP_ZOOM.RESULT);
     expect(instance.center).toEqual([0, 0]);
     expect(spy1).toHaveBeenCalledWith({

--- a/app/src/components/searchResultMap.spec.js
+++ b/app/src/components/searchResultMap.spec.js
@@ -263,7 +263,7 @@ describe("SearchResultMap", () => {
     instance.renderMap();
     expect(spy).toHaveBeenCalledTimes(2);
     expect(instance.gBaseTiles.childNodes).toBeDefined();
-    expect(instance.gRsTiles.childNodes).toBeDefined();
+    expect(instance.gRsLayer.childNodes).toBeDefined();
   });
 
   test("setMapSize", () => {

--- a/app/src/components/searchResultMap.spec.js
+++ b/app/src/components/searchResultMap.spec.js
@@ -50,6 +50,11 @@ describe("SearchResultMap", () => {
         error: null,
         match: null,
       },
+      rentStabilizedGeoJson: {
+        status: "idle",
+        error: null,
+        geojson: null,
+      },
     }));
 
     fetch.mockResponse(
@@ -116,7 +121,7 @@ describe("SearchResultMap", () => {
   test("uses observeStore to watch for redux state changes", () => {
     const store = require("../store");
     const spy = jest.spyOn(store, "observeStore");
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledTimes(2);
     spy.mockRestore();
   });
 
@@ -130,7 +135,7 @@ describe("SearchResultMap", () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
-  test("handleSearchResult", () => {
+  test("handleSearchResult", async () => {
     const spy = jest.spyOn(SearchResultMap.prototype, "updateMapView");
     const instance = new SearchResultMap({ element, store });
     store.getState.mockImplementation(() => ({
@@ -160,8 +165,13 @@ describe("SearchResultMap", () => {
         error: null,
         match: null,
       },
+      rentStabilizedGeoJson: {
+        status: "idle",
+        error: null,
+        geojson: null,
+      },
     }));
-    instance.handleSearchResult();
+    await instance.handleSearchResult();
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
@@ -207,6 +217,11 @@ describe("SearchResultMap", () => {
         error: null,
         match: null,
       },
+      rentStabilizedGeoJson: {
+        status: "idle",
+        error: null,
+        geojson: null,
+      },
     }));
     await instance.updateMapView();
     expect(instance.zoom).toEqual(MAP_ZOOM.RESULT);
@@ -240,12 +255,12 @@ describe("SearchResultMap", () => {
     expect(spy6).not.toHaveBeenCalled();
   });
 
-  test("renderMap", () => {
+  test("renderMap", async () => {
     MapTileLayers.mockRestore();
     const { SearchResultMap } = require("./searchResultMap");
     const spy = jest.spyOn(SearchResultMap.prototype, "setMapSize");
     const instance = new SearchResultMap({ element, store });
-    instance.renderMap();
+    await instance.renderMap();
     expect(spy).toHaveBeenCalledTimes(1);
     expect(instance.gBaseTiles.childNodes).toBeDefined();
     expect(instance.gRsTiles.childNodes).toBeDefined();
@@ -293,12 +308,12 @@ describe("SearchResultMap", () => {
     expect(searchResultMap.marker.getAttribute("opacity")).toBe("0");
   });
 
-  test("resetMap", () => {
+  test("resetMap", async () => {
     const spy1 = jest.spyOn(SearchResultMap.prototype, "hideMarker");
     const spy2 = jest.spyOn(SearchResultMap.prototype, "renderMap");
     const spy3 = jest.spyOn(MapPopup.prototype, "hide");
     const instance = new SearchResultMap({ store, element });
-    instance.resetMap();
+    await instance.resetMap();
     expect(spy1).toHaveBeenCalledTimes(1);
     expect(spy2).toHaveBeenCalledTimes(1);
     expect(spy3).toHaveBeenCalledTimes(1);

--- a/app/src/constants/actionTypes.js
+++ b/app/src/constants/actionTypes.js
@@ -22,6 +22,12 @@ export const RentStabilizedSuccess = "RentStabilizedSuccess";
 export const RentStabilizedFailure = "RentStabilizedFailure";
 export const RentStabilizedReset = "RentStabilizedReset";
 
+// rent stabilized geojson boundaries
+export const RentStabilizedGeoJsonRequest = "RentStabilizedGeoJsonRequest";
+export const RentStabilizedGeoJsonSuccess = "RentStabilizedGeoJsonSuccess";
+export const RentStabilizedGeoJsonFailure = "RentStabilizedGeoJsonFailure";
+export const RentStabilizedGeoJsonReset = "RentStabilizedGeoJsonReset";
+
 // tenants rights groups search
 export const TenantsRightsRequest = "TenantsRightsRequest";
 export const TenantsRightsSuccess = "TenantsRightsSuccess";

--- a/app/src/constants/config.js
+++ b/app/src/constants/config.js
@@ -1,14 +1,12 @@
-// CARTO account config related
-export const cartoAccount = "chenrick";
-export const rentStabilizedTable = "mappluto_likely_rs_2020_v8";
+/** NYC Planning Labs API version */
 export const geosearchApiVersion = "v2";
 
+// CARTO account config related
 export const cartoAPIv3BaseURL = "https://gcp-us-east1.api.carto.com";
 export const cartoV3RentStabilizedTableName =
   "shared.mappluto_likely_rs_2020_v8";
 export const cartoV3TenantsRightsServiceAreasTable =
   "shared.nyc_tenants_rights_service_areas";
-
 // NOTE: this API key is restricted for use on the domain https://amirentstabilized.com
 export const cartoApiKey =
   "eyJhbGciOiJIUzI1NiJ9.eyJhIjoiYWNfd3cwaDFiczgiLCJqdGkiOiIyOTVmZGRkNiJ9.w6GC-oesQEl5HerTbTlZWxFb8-c8iX7F0NAG9pCunu0";

--- a/app/src/hbs_partials/search_result_map.hbs
+++ b/app/src/hbs_partials/search_result_map.hbs
@@ -10,7 +10,7 @@
       Geographic map showing NYC properties that may be rent stabilized.
     </desc>
     <g class="tiles-base-map"></g>
-    <g class="tiles-rent-stabilized"></g>
+    <g class="layer-rent-stabilized"></g>
     <g
       class="location-marker"
       transform="translate(264, 137),scale(2)"

--- a/app/src/preloaded-state.js
+++ b/app/src/preloaded-state.js
@@ -5,95 +5,142 @@
  */
 export const preloadedState = {
   slides: {
-    curIndex: 7,
+    curIndex: 3,
+  },
+  addressGeocode: {
+    status: "idle",
+    error: null,
+    searchResult: {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: {
+            type: "Point",
+            coordinates: [-73.95757, 40.658],
+          },
+          properties: {
+            id: "1251947",
+            gid: "nycpad:venue:1251947",
+            layer: "venue",
+            source: "nycpad",
+            source_id: "1251947",
+            country_code: "US",
+            name: "146 FENIMORE STREET",
+            housenumber: "146",
+            street: "FENIMORE STREET",
+            postalcode: "11225",
+            accuracy: "point",
+            country: "United States",
+            country_gid: "whosonfirst:country:85633793",
+            country_a: "USA",
+            region: "New York",
+            region_gid: "whosonfirst:region:85688543",
+            region_a: "NY",
+            county: "Kings County",
+            county_gid: "whosonfirst:county:102082361",
+            county_a: "BK",
+            locality: "New York",
+            locality_gid: "whosonfirst:locality:85977539",
+            locality_a: "NYC",
+            borough: "Brooklyn",
+            borough_gid: "whosonfirst:borough:421205765",
+            neighbourhood: "Prospect",
+            neighbourhood_gid: "whosonfirst:neighbourhood:85892955",
+            label: "146 FENIMORE STREET, Brooklyn, NY, USA",
+            addendum: {
+              pad: {
+                bbl: "3050420047",
+                bin: "3115518",
+                version: "24d",
+              },
+            },
+          },
+        },
+      ],
+    },
   },
   tenantsRights: {
     status: "idle",
     results: {
       rows: [
         {
-          name: "North West Bushwick Community Group",
-          full_address: "",
-          email: "NWBcommunity@gmail.com",
-          phone: "",
-          description: "community group serving Bushwick, Brooklyn, NY",
-          service_area: "Bushwick",
-          website_url: "NWBcommunity.org",
+          name: "Movement to Protect the People",
+          full_address: null,
+          email: "info@mtopp.org",
+          phone: "(718) 703-3086",
+          description: "anti-displacement activist group",
+          service_area: "Prospect Lefferts Gardens",
+          website_url: "http://mtopp.org/",
         },
         {
-          name: "Make The Road New York (Brooklyn)",
-          full_address: "301 Grove Street  BK 11237",
-          email: "",
-          phone: "(718) 418-7690",
+          name: "Prospect Park East Network",
+          full_address: null,
+          email: "ppeastnet@gmail.com",
+          phone: "347 413-9273",
           description:
-            "Make the Road New York (MRNY) builds the power of Latino and working class communities to achieve dignity and justice through organizing, policy innovation, transformative education, and survival services.",
-          service_area: "Bushwick",
-          website_url: "http://www.maketheroad.org/",
-        },
-        {
-          name:
-            "Ridgewood Bushwick Senior Citizens Council Legal Empowerment & Assistance Program (Bushwick Office)",
-          full_address: "1475 Myrtle Ave.  BK 11237",
-          email: "",
-          phone: "(347) 295-3738",
-          description:
-            "homeless prevention, re-housing from shelter, legal services, veteran’s services, adult education, and job training and placement.  We also offer ongoing tenants’ rights and financial literacy trainings for community residents.",
-          service_area: "Bushwick",
-          website_url: "http://www.empowermentcenter.org",
-        },
-        {
-          name: "Bushwick Housing Independence Project",
-          full_address: "",
-          email: "bhipbrooklyn@gmail.com",
-          phone: "",
-          description:
-            "The Bushwick Housing Independence Project helps to preserve existing affordable housing for low and moderate-income families in Bushwick.",
-          service_area: "Bushwick",
-          website_url: "http://www.bhip-brooklyn.org/",
-        },
-        {
-          name: "Ridgewood Bushwick Senior Citizens Council (main office)",
-          full_address: "217 Wyckoff Avenue  BK 11237",
-          email: "<nstanczyk@rbscc.org",
-          phone: "718 366 3800 x1005",
-          description:
-            "homeless prevention, re-housing from shelter, legal services, veteran’s services, adult education, and job training and placement.  We also offer ongoing tenants’ rights and financial literacy trainings for community residents.",
-          service_area: "Bushwick",
-          website_url: "http://www.empowermentcenter.org",
+            "PPEN is an organization of concerned residents formed to address irresponsible development (e.g. 626 Flatbush, 23 floors towing over the Park) and the larger concerns it brings, which include the urgent need for contextual zoning and impact studies on such issues as low income and affordable housing, traffic, subways, parking, schools, safety, sanitation and the Park itself.",
+          service_area: "Prospect Lefferts Gardens",
+          website_url: "http://www.ppen.org/",
         },
       ],
-      time: 0.005,
-      fields: {
-        name: {
+      schema: [
+        {
+          name: "name",
           type: "string",
-          pgtype: "text",
         },
-        full_address: {
+        {
+          name: "full_address",
           type: "string",
-          pgtype: "text",
         },
-        email: {
+        {
+          name: "email",
           type: "string",
-          pgtype: "text",
         },
-        phone: {
+        {
+          name: "phone",
           type: "string",
-          pgtype: "text",
         },
-        description: {
+        {
+          name: "description",
           type: "string",
-          pgtype: "text",
         },
-        service_area: {
+        {
+          name: "service_area",
           type: "string",
-          pgtype: "text",
         },
-        website_url: {
+        {
+          name: "website_url",
           type: "string",
-          pgtype: "text",
         },
+      ],
+      meta: {
+        cacheHit: false,
+        totalBytesProcessed: "486756",
+        location: "US",
       },
-      total_rows: 5,
+    },
+    error: null,
+  },
+  rentStabilized: {
+    status: "idle",
+    match: {
+      rows: [
+        {
+          bbl: 3050420047,
+        },
+      ],
+      schema: [
+        {
+          name: "bbl",
+          type: "number",
+        },
+      ],
+      meta: {
+        cacheHit: false,
+        totalBytesProcessed: "486848",
+        location: "US",
+      },
     },
     error: null,
   },

--- a/app/src/reducers/index.js
+++ b/app/src/reducers/index.js
@@ -2,6 +2,7 @@ import { combineReducers } from "redux";
 import { slides } from "./slidesReducer";
 import { addressGeocode } from "./addressGeocodeReducer";
 import { rentStabilized } from "./rentStabilizedReducer";
+import { rentStabilizedGeoJson } from "./rentStabilizedGeoJsonReducer";
 import { tenantsRights } from "./tenantsRightsReducer";
 
 export const rootReducer = combineReducers({
@@ -9,4 +10,5 @@ export const rootReducer = combineReducers({
   addressGeocode,
   tenantsRights,
   rentStabilized,
+  rentStabilizedGeoJson,
 });

--- a/app/src/reducers/rentStabilizedGeoJsonReducer.js
+++ b/app/src/reducers/rentStabilizedGeoJsonReducer.js
@@ -1,0 +1,50 @@
+import * as types from "../constants/actionTypes";
+
+/**
+ * @typedef {object} State
+ * @property {string} status
+ * @property {null | object}
+ * @property {null | object}
+ **/
+
+/** @type {State} */
+export const initialState = {
+  status: "idle",
+  geojson: null,
+  error: null,
+};
+
+/**
+ *
+ * @param {State} state
+ * @param {string} action
+ * @returns {State}
+ */
+export function rentStabilizedGeoJson(state = initialState, action) {
+  switch (action.type) {
+    case types.RentStabilizedGeoJsonRequest:
+      return {
+        ...state,
+        status: "pending",
+      };
+    case types.RentStabilizedGeoJsonSuccess:
+      return {
+        ...state,
+        status: "idle",
+        geojson: action.payload,
+      };
+    case types.RentStabilizedGeoJsonFailure:
+      return {
+        ...state,
+        status: "error",
+        error: action.error,
+      };
+    case types.ResetAppState:
+    case types.RentStabilizedGeoJsonReset:
+      return {
+        ...initialState,
+      };
+    default:
+      return state;
+  }
+}

--- a/app/src/reducers/rentStabilizedGeoJsonReducer.js
+++ b/app/src/reducers/rentStabilizedGeoJsonReducer.js
@@ -3,8 +3,8 @@ import * as types from "../constants/actionTypes";
 /**
  * @typedef {object} State
  * @property {string} status
- * @property {null | object}
- * @property {null | object}
+ * @property {null | []} geojson
+ * @property {null | Error} error
  **/
 
 /** @type {State} */

--- a/app/src/reducers/rentStabilizedGeoJsonReducer.spec.js
+++ b/app/src/reducers/rentStabilizedGeoJsonReducer.spec.js
@@ -1,0 +1,86 @@
+import * as types from "../constants/actionTypes";
+import {
+  rentStabilizedGeoJson,
+  initialState,
+} from "./rentStabilizedGeoJsonReducer";
+
+describe("rentStabilizedGeoJson reducer", () => {
+  test("Should return the default state", () => {
+    expect(rentStabilizedGeoJson(undefined, {})).toEqual(initialState);
+  });
+
+  test("Should handle RentStabilizedGeoJsonRequest", () => {
+    expect(
+      rentStabilizedGeoJson(initialState, {
+        type: types.RentStabilizedGeoJsonRequest,
+      })
+    ).toEqual({
+      ...initialState,
+      status: "pending",
+    });
+  });
+
+  test("Should handle RentStabilizedGeoJsonSuccess", () => {
+    expect(
+      rentStabilizedGeoJson(initialState, {
+        type: types.RentStabilizedGeoJsonSuccess,
+        payload: [],
+      })
+    ).toEqual({
+      ...initialState,
+      status: "idle",
+      geojson: [],
+    });
+  });
+
+  test("Should handle RentStabilizedGeoJsonFailure", () => {
+    expect(
+      rentStabilizedGeoJson(initialState, {
+        type: types.RentStabilizedGeoJsonFailure,
+        error: new Error(),
+      })
+    ).toEqual({
+      ...initialState,
+      status: "error",
+      error: new Error(),
+    });
+  });
+
+  test("Should handle RentStabilizedGeoJsonReset", () => {
+    expect(
+      rentStabilizedGeoJson(
+        {
+          status: "idle",
+          geojson: [],
+          error: null,
+        },
+        {
+          type: types.RentStabilizedGeoJsonReset,
+        }
+      )
+    ).toEqual({
+      status: "idle",
+      error: null,
+      geojson: null,
+    });
+  });
+
+  test("Should handle ResetAppState", () => {
+    expect(
+      rentStabilizedGeoJson(
+        {
+          status: "idle",
+          match: [],
+          error: null,
+        },
+        {
+          type: types.ResetAppState,
+        }
+      )
+    ).toEqual({
+      status: "idle",
+      error: null,
+      geojson: null,
+    });
+  });
+});

--- a/app/src/utils/cartoSqlApiAuth.js
+++ b/app/src/utils/cartoSqlApiAuth.js
@@ -1,0 +1,18 @@
+import { cartoApiKey } from "../constants/config";
+
+/**
+ * creates the expected fetch request options for Carto SQL API calls
+ * @returns {object}
+ */
+export const cartoSqlApiAuthOptions = () => {
+  const headers = new Headers();
+  headers.append("Authorization", `Bearer ${cartoApiKey}`);
+
+  const requestOptions = {
+    method: "GET",
+    headers: headers,
+    redirect: "follow",
+  };
+
+  return requestOptions;
+};

--- a/app/src/utils/cartoSqlApiAuth.js
+++ b/app/src/utils/cartoSqlApiAuth.js
@@ -4,7 +4,7 @@ import { cartoApiKey } from "../constants/config";
  * creates the expected fetch request options for Carto SQL API calls
  * @returns {object}
  */
-export const cartoSqlApiAuthOptions = () => {
+export const getCartoSqlApiAuthOptions = () => {
   const headers = new Headers();
   headers.append("Authorization", `Bearer ${cartoApiKey}`);
 

--- a/app/src/utils/geoUtils.js
+++ b/app/src/utils/geoUtils.js
@@ -1,0 +1,35 @@
+import { rewind } from "@turf/rewind";
+
+/**
+ * @typedef {object} Row
+ * @property {string} geojson
+ */
+
+/**
+ * @typedef {object} Feature
+ * @property {string} type
+ * @property {object} properties
+ * @property {object} geometry
+ */
+
+/**
+ * converts Carto SQL API stringified GeoJSON geometries to an array of GeoJSON features
+ * @param {Row[]} rows - query rows result
+ * @returns {Feature[]}
+ */
+export function parseTransformRsGeomQueryResult(rows) {
+  const features = rows
+    .filter((d) => typeof d.geojson === "string" && d.geojson.length)
+    .map((d) =>
+      rewind(
+        {
+          type: "Feature",
+          // TODO: include `id` here?
+          properties: {},
+          geometry: JSON.parse(d.geojson),
+        },
+        { reverse: true }
+      )
+    );
+  return features;
+}

--- a/app/src/utils/sql.js
+++ b/app/src/utils/sql.js
@@ -4,11 +4,18 @@ import {
   cartoV3TenantsRightsServiceAreasTable,
 } from "../constants/config";
 
+const searchResultBufferDistance = 500; // meters
+
 export const rentStabilizedBblSql = (bbl) =>
   `SELECT bbl FROM ${cartoV3RentStabilizedTableName} WHERE bbl = ${bbl}`;
 
 export const mapsApiSql = () =>
   `SELECT the_geom_webmercator FROM ${rentStabilizedTable}`;
+
+export const rentStabilizedGeomSql = ({ lon, lat }) =>
+  `SELECT ST_ASGEOJSON(geom) as geojson
+		FROM ${cartoV3RentStabilizedTableName}
+		WHERE ST_DWithin(geom, ST_GeogFromText('POINT(${lon} ${lat})'), ${searchResultBufferDistance})`;
 
 export const tenantsRightsGroupsSql = ({ lon, lat }) =>
   `SELECT

--- a/app/src/utils/sql.js
+++ b/app/src/utils/sql.js
@@ -1,5 +1,4 @@
 import {
-  rentStabilizedTable,
   cartoV3RentStabilizedTableName,
   cartoV3TenantsRightsServiceAreasTable,
 } from "../constants/config";
@@ -8,9 +7,6 @@ const searchResultBufferDistance = 500; // meters
 
 export const rentStabilizedBblSql = (bbl) =>
   `SELECT bbl FROM ${cartoV3RentStabilizedTableName} WHERE bbl = ${bbl}`;
-
-export const mapsApiSql = () =>
-  `SELECT the_geom_webmercator FROM ${rentStabilizedTable}`;
 
 export const rentStabilizedGeomSql = ({ lon, lat }) =>
   `SELECT ST_ASGEOJSON(geom) as geojson

--- a/app/src/utils/sql.js
+++ b/app/src/utils/sql.js
@@ -10,9 +10,9 @@ export const rentStabilizedBblSql = (bbl) =>
   `SELECT bbl FROM ${cartoV3RentStabilizedTableName} WHERE bbl = ${bbl}`;
 
 export const rentStabilizedGeomSql = ({ lon, lat }) =>
-  sls`SELECT ST_ASGEOJSON(geom) as geojson
-		FROM ${cartoV3RentStabilizedTableName}
-		WHERE ST_DWithin(
+  sls`SELECT ST_AsGeoJSON(geom) as geojson
+    FROM ${cartoV3RentStabilizedTableName}
+    WHERE ST_DWithin(
       geom,
       ST_GeogFromText(
         'POINT(' || ${lon} || ' ' || ${lat} ||')'

--- a/app/src/utils/sql.js
+++ b/app/src/utils/sql.js
@@ -1,3 +1,4 @@
+import sls from "single-line-string";
 import {
   cartoV3RentStabilizedTableName,
   cartoV3TenantsRightsServiceAreasTable,
@@ -9,12 +10,18 @@ export const rentStabilizedBblSql = (bbl) =>
   `SELECT bbl FROM ${cartoV3RentStabilizedTableName} WHERE bbl = ${bbl}`;
 
 export const rentStabilizedGeomSql = ({ lon, lat }) =>
-  `SELECT ST_ASGEOJSON(geom) as geojson
+  sls`SELECT ST_ASGEOJSON(geom) as geojson
 		FROM ${cartoV3RentStabilizedTableName}
-		WHERE ST_DWithin(geom, ST_GeogFromText('POINT(${lon} ${lat})'), ${searchResultBufferDistance})`;
+		WHERE ST_DWithin(
+      geom,
+      ST_GeogFromText(
+        'POINT(' || ${lon} || ' ' || ${lat} ||')'
+      ),
+      ${searchResultBufferDistance}
+    )`;
 
 export const tenantsRightsGroupsSql = ({ lon, lat }) =>
-  `SELECT
+  sls`SELECT
     name,
     full_address,
     email,

--- a/app/src/utils/sql.spec.js
+++ b/app/src/utils/sql.spec.js
@@ -1,11 +1,30 @@
 import * as sql from "./sql";
-import { cartoV3RentStabilizedTableName } from "../constants/config";
+import {
+  cartoV3RentStabilizedTableName,
+  cartoV3TenantsRightsServiceAreasTable,
+} from "../constants/config";
 
 describe("utils/sql", () => {
   test("rentStabilizedBblSql", () => {
     const result = sql.rentStabilizedBblSql("999999999");
     expect(result).toBe(
       `SELECT bbl FROM ${cartoV3RentStabilizedTableName} WHERE bbl = 999999999`
+    );
+  });
+
+  test("rentStabilizedGeomSql", () => {
+    const [lon, lat] = [-73, 40];
+    const result = sql.rentStabilizedGeomSql({ lon, lat });
+    expect(result).toBe(
+      `SELECT ST_AsGeoJSON(geom) as geojson FROM ${cartoV3RentStabilizedTableName} WHERE ST_DWithin( geom, ST_GeogFromText( 'POINT(' || ${lon} || ' ' || ${lat} ||')' ), 500 )`
+    );
+  });
+
+  test("tenantsRightsGroupsSql", () => {
+    const [lon, lat] = [-73, 40];
+    const result = sql.tenantsRightsGroupsSql({ lon, lat });
+    expect(result).toBe(
+      `SELECT name, full_address, email, phone, description, service_area, website_url FROM ${cartoV3TenantsRightsServiceAreasTable} WHERE ST_Contains( geom, ST_GeogFromText( 'POINT(' || ${lon} || ' ' || ${lat} ||  ')' ) )`
     );
   });
 });

--- a/app/src/utils/sql.spec.js
+++ b/app/src/utils/sql.spec.js
@@ -1,21 +1,11 @@
 import * as sql from "./sql";
-import {
-  rentStabilizedTable,
-  cartoV3RentStabilizedTableName,
-} from "../constants/config";
+import { cartoV3RentStabilizedTableName } from "../constants/config";
 
 describe("utils/sql", () => {
   test("rentStabilizedBblSql", () => {
     const result = sql.rentStabilizedBblSql("999999999");
     expect(result).toBe(
       `SELECT bbl FROM ${cartoV3RentStabilizedTableName} WHERE bbl = 999999999`
-    );
-  });
-
-  test("mapsApiSql", () => {
-    const result = sql.mapsApiSql();
-    expect(result).toBe(
-      `SELECT the_geom_webmercator FROM ${rentStabilizedTable}`
     );
   });
 });

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2553,9 +2553,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001449:
-  version "1.0.30001564"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001564.tgz"
-  integrity sha512-DqAOf+rhof+6GVx1y+xzbFPeOumfQnhYzVnZD6LAXijR77yPtm9mfOcqOnT3mpnJiZVT+kwLAFnRlZcIz+c6bg==
+  version "1.0.30001704"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001704.tgz"
+  integrity sha512-+L2IgBbV6gXB4ETf0keSvLr7JUrRVbIaB/lrQ1+z8mRcQiisG5k+lG6O4n6Y5q6f5EuNfaYXKgymucphlEXQew==
 
 capture-exit@^2.0.0:
   version "2.0.0"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1162,6 +1162,63 @@
     remark "^12.0.0"
     unist-util-find-all-after "^3.0.1"
 
+"@turf/boolean-clockwise@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-clockwise/-/boolean-clockwise-7.2.0.tgz#5ecfbdba3a9a7cad83bea63876aab8f2a3539a23"
+  integrity sha512-0fJeFSARxy6ealGBM4Gmgpa1o8msQF87p2Dx5V6uSqzT8VPDegX1NSWl4b7QgXczYa9qv7IAABttdWP0K7Q7eQ==
+  dependencies:
+    "@turf/helpers" "^7.2.0"
+    "@turf/invariant" "^7.2.0"
+    "@types/geojson" "^7946.0.10"
+    tslib "^2.8.1"
+
+"@turf/clone@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/clone/-/clone-7.2.0.tgz#1dbf6e2f82ba2f9da45285fb870aa40662ccc55f"
+  integrity sha512-JlGUT+/5qoU5jqZmf6NMFIoLDY3O7jKd53Up+zbpJ2vzUp6QdwdNzwrsCeONhynWM13F0MVtPXH4AtdkrgFk4g==
+  dependencies:
+    "@turf/helpers" "^7.2.0"
+    "@types/geojson" "^7946.0.10"
+    tslib "^2.8.1"
+
+"@turf/helpers@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-7.2.0.tgz#5771308108c98d608eb8e7f16dcd0eb3fb8a3417"
+  integrity sha512-cXo7bKNZoa7aC7ydLmUR02oB3IgDe7MxiPuRz3cCtYQHn+BJ6h1tihmamYDWWUlPHgSNF0i3ATc4WmDECZafKw==
+  dependencies:
+    "@types/geojson" "^7946.0.10"
+    tslib "^2.8.1"
+
+"@turf/invariant@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-7.2.0.tgz#ba5b377ea20ee8c45af0a4c9b8bf03aa1c43bd5d"
+  integrity sha512-kV4u8e7Gkpq+kPbAKNC21CmyrXzlbBgFjO1PhrHPgEdNqXqDawoZ3i6ivE3ULJj2rSesCjduUaC/wyvH/sNr2Q==
+  dependencies:
+    "@turf/helpers" "^7.2.0"
+    "@types/geojson" "^7946.0.10"
+    tslib "^2.8.1"
+
+"@turf/meta@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-7.2.0.tgz#6a6b1918890b4d9d2b5ff10b3ad47e2fd7470912"
+  integrity sha512-igzTdHsQc8TV1RhPuOLVo74Px/hyPrVgVOTgjWQZzt3J9BVseCdpfY/0cJBdlSRI4S/yTmmHl7gAqjhpYH5Yaw==
+  dependencies:
+    "@turf/helpers" "^7.2.0"
+    "@types/geojson" "^7946.0.10"
+
+"@turf/rewind@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/rewind/-/rewind-7.2.0.tgz#c7f56d7298691799d0324672d24937009bf99fbe"
+  integrity sha512-SZpRAZiZsE22+HVz6pEID+ST25vOdpAMGk5NO1JeqzhpMALIkIGnkG+xnun2CfYHz7wv8/Z0ADiAvei9rkcQYA==
+  dependencies:
+    "@turf/boolean-clockwise" "^7.2.0"
+    "@turf/clone" "^7.2.0"
+    "@turf/helpers" "^7.2.0"
+    "@turf/invariant" "^7.2.0"
+    "@turf/meta" "^7.2.0"
+    "@types/geojson" "^7946.0.10"
+    tslib "^2.8.1"
+
 "@types/anymatch@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-3.0.0.tgz#c95ff14401dbb2869913afac3935af4ad0d37f1a"
@@ -1219,6 +1276,11 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.0.tgz#5fb2e536c1ae9bf35366eed879e827fa59ca41c2"
   integrity sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==
+
+"@types/geojson@^7946.0.10":
+  version "7946.0.16"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.16.tgz#8ebe53d69efada7044454e3305c19017d97ced2a"
+  integrity sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==
 
 "@types/glob@^7.1.1":
   version "7.2.0"
@@ -10137,6 +10199,11 @@ tslib@^2.0.3:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+
+tslib@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tsutils@^3.17.1:
   version "3.17.1"


### PR DESCRIPTION
Addresses #150 

- Use the Carto SQL API (v3) to generate a GeoJSON layer of likely RS taxlots within proximity to search result
- Removes the usage of soon to be deprecated Carto Maps API (v2) that generated a tile layer of likely RS taxlots
- Adds a dependency `@turf/rewind` to fix GeoJSON polygon winding order returned by Big Query's `ST_AsGeoJSON` so that `d3-geo` may correctly render the polygons as SVG `<path>`s
- Removes dead code no longer relevant to Carto Maps API v2
- Adds a few unit tests for the SQL string generation
- updates the browserlist db in `yarn.lock`