### PR TITLE
Fix video embed size in why page

### DIFF
--- a/app/src/hbs_templates/why.hbs
+++ b/app/src/hbs_templates/why.hbs
@@ -81,6 +81,8 @@
     <div class="video" style="--aspect-ratio: 16/9;">
       <iframe
         src="https://www.youtube.com/embed/uvZWZy9uZqA"
+        {{!-- TODO: add translation for title attribute --}}
+        title="Video: How Did We Get Here?"
         frameborder="0"
         width="960"
         height="540"
@@ -94,6 +96,8 @@
     <div class="video" style="--aspect-ratio: 16/9;">
       <iframe
         src="https://www.youtube.com/embed/9MB-BhoUXg4"
+        {{!-- TODO: add translation for title attribute --}}
+        title="Video: What's Vacancy Decontrol"
         frameborder="0"
         width="960"
         height="540"
@@ -107,6 +111,8 @@
     <div class="video" style="--aspect-ratio: 16/9;">
       <iframe
         src="https://www.youtube.com/embed/Yn8tj-8-TeE"
+        {{!-- TODO: add translation for title attribute --}}
+        title="Video: Tenant's project, The Bronx"
         frameborder="0"
         width="960"
         height="540"
@@ -120,6 +126,8 @@
     <div class="video" style="--aspect-ratio: 16/9;">
       <iframe
         src="https://www.youtube.com/embed/6oSbEpdL968"
+        {{!-- TODO: add translation for title attribute --}}
+        title="Video: Tenant's project, Bushwick"
         frameborder="0"
         width="960"
         height="540"
@@ -133,6 +141,8 @@
     <div class="video" style="--aspect-ratio: 16/9;">
       <iframe
         src="https://www.youtube.com/embed/TtZmANXveXg"
+        {{!-- TODO: add translation for title attribute --}}
+        title="Video: Tenant's project, Chinatown"
         frameborder="0"
         width="960"
         height="540"

--- a/app/src/hbs_templates/why.hbs
+++ b/app/src/hbs_templates/why.hbs
@@ -82,6 +82,8 @@
       <iframe
         src="https://www.youtube.com/embed/uvZWZy9uZqA"
         frameborder="0"
+        width="960"
+        height="540"
         loading="lazy"
         allowfullscreen
       >
@@ -93,6 +95,8 @@
       <iframe
         src="https://www.youtube.com/embed/9MB-BhoUXg4"
         frameborder="0"
+        width="960"
+        height="540"
         loading="lazy"
         allowfullscreen
       >
@@ -104,6 +108,8 @@
       <iframe
         src="https://www.youtube.com/embed/Yn8tj-8-TeE"
         frameborder="0"
+        width="960"
+        height="540"
         loading="lazy"
         allowfullscreen
       >
@@ -115,6 +121,8 @@
       <iframe
         src="https://www.youtube.com/embed/6oSbEpdL968"
         frameborder="0"
+        width="960"
+        height="540"
         loading="lazy"
         allowfullscreen
       >
@@ -126,6 +134,8 @@
       <iframe
         src="https://www.youtube.com/embed/TtZmANXveXg"
         frameborder="0"
+        width="960"
+        height="540"
         loading="lazy"
         allowfullscreen
       >

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -191,7 +191,13 @@ module.exports = (env, argv) => {
           extractComments: true,
           sourceMap: true,
         }),
-        new OptimizeCSSAssetsPlugin({}),
+        new OptimizeCSSAssetsPlugin({
+          cssProcessorPluginOptions: {
+            // disable calc optimization as it incorrectly removes parenthesis around css custom properties
+            // this happens in _embed.scss with `calc(100% / (var(--aspect-ratio)))`
+            preset: ["default", { calc: false }],
+          },
+        }),
       ],
 
       // how webpack should split our code compiled into separate files for production

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -8,7 +8,7 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const TerserJSPlugin = require("terser-webpack-plugin");
 const StylelintPlugin = require("stylelint-webpack-plugin");
-const ESLintPlugin = require('eslint-webpack-plugin');
+const ESLintPlugin = require("eslint-webpack-plugin");
 
 // `module.exports` is NodeJS's way of exporting code from a file,
 // so that it can be made available in other files. It's what
@@ -139,7 +139,7 @@ module.exports = (env, argv) => {
               options: {
                 cacheDirectory: true,
               },
-            }
+            },
           ],
         },
 
@@ -297,12 +297,10 @@ module.exports = (env, argv) => {
       // want in production, such as logging
       new webpack.DefinePlugin({
         "process.env.NODE_ENV": JSON.stringify(env.NODE_ENV),
-        "process.env.USE_REDUX_LOGGER": JSON.stringify(
-          env.USE_REDUX_LOGGER
-        ),
+        "process.env.USE_REDUX_LOGGER": JSON.stringify(env.USE_REDUX_LOGGER),
         "process.env.USE_PRELOADED_STATE": JSON.stringify(
           env.USE_PRELOADED_STATE
-        )
+        ),
       }),
     ],
   };


### PR DESCRIPTION
Fixes responsive iframes in the why info page:
- disables a webpack `OptimizeCSSAssetsPlugin` calc optimization rule that was causing the CSS to not work as intended
- adds natural width and height to iframe elements to allow them to have a natural height & width which can be scaled
- adds `title` attributes to iframe elements for their accessible names